### PR TITLE
Python 2.6-compatible str.format() usage.

### DIFF
--- a/pytest_spec/patch.py
+++ b/pytest_spec/patch.py
@@ -58,7 +58,7 @@ def _get_test_name(nodeid):
         test_name_parts = test_name.split('  ')
         if len(test_name_parts) == 1:
             return test_name.strip().capitalize()
-        return 'The ({}) {}'.format(test_name_parts[0][1:].replace(' ', '_'), test_name_parts[1])
+        return 'The ({0}) {1}'.format(test_name_parts[0][1:].replace(' ', '_'), test_name_parts[1])
     return test_name
 
 
@@ -73,4 +73,4 @@ def _format_results(report):
 
 def _print_test_result(self, test_name, test_status, markup):
     self._tw.line()
-    self._tw.write("    {}{}".format(test_status, test_name), **markup)
+    self._tw.write("    {0}{1}".format(test_status, test_name), **markup)


### PR DESCRIPTION
The only thing preventing use of this package under Python 2.6 is the current use of automatic positional `str.format()` replacements.  Adding indices to them makes it work in a version-agnostic way.

Needed for marrow/cache's test suite.