### PR TITLE
Honor capitalization of words in test name

### DIFF
--- a/pytest_spec/patch.py
+++ b/pytest_spec/patch.py
@@ -4,6 +4,8 @@
 :author: Pawel Chomicki
 """
 
+import re
+
 
 def pytest_runtest_logstart(self, nodeid, location):
     """Signal the start of running a single test item.
@@ -52,8 +54,24 @@ def _print_class_information(self):
     self._first_triggered = True
 
 
+def _remove_module_name(nodeid):
+    return nodeid.rsplit("::", 1)[1]
+
+
+def _remove_test_prefix(nodeid):
+    return re.sub("^test_+", "", nodeid)
+
+
+def _replace_underscores(nodeid):
+    return nodeid.replace("_", " ").strip()
+
+
+def _capitalize_first_letter(s):
+    return s[:1].capitalize() + s[1:]
+
+
 def _get_test_name(nodeid):
-    test_name = nodeid.rsplit("::", 1)[1][5:].replace("_", " ").capitalize()
+    test_name = _capitalize_first_letter(_replace_underscores(_remove_test_prefix(_remove_module_name(nodeid))))
     if test_name[:1] is ' ':
         test_name_parts = test_name.split('  ')
         if len(test_name_parts) == 1:

--- a/test/test_patch.py
+++ b/test/test_patch.py
@@ -96,6 +96,11 @@ class TestPatch(unittest.TestCase):
         pytest_runtest_logreport(fake_self, FakeReport('Test::Second::test__example'))
         fake_self._tw.assert_has_calls(call('    [PASS]  Example', green=True))
 
+    def test__pytest_runtest_logreport__honors_capitalization_of_words_in_test_name(self):
+        fake_self = FakeSelf()
+        pytest_runtest_logreport(fake_self, FakeReport('Test::Second::test_example_Demo_CamelCase'))
+        fake_self._tw.assert_has_calls(call('    [PASS]  Example Demo CamelCase', green=True))
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
I sometimes refer to class names (which are written in CamelCase) in my tests and `pytest-spec` converts these to lowercase, which makes reading them harder. This PR changes the behaviour so that `pytest-spec` only capitalizes the first letter in the test name.

I also took the liberty to separate out a few helper functions to make it clearer what's actually happening in splitting the test name.

I added at test, but unfortunately when I run the tests locally a bunch of them fail (even before my PR), so I'm not sure if anything is wrong with my setup. I thought I'd wait for the drone.io results before spending time investigating this.