### PR TITLE
Make class information human readable

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -29,6 +29,32 @@ Output example
         [SKIP]  Some method return none
 
 
+Configuration
+=============
+
+``spec_header_format``
+----------------------
+
+You can configure the format of the test headers by specifying a `format string <https://docs.python.org/2/library/string.html#format-string-syntax>`_ in your `ini-file <http://doc.pytest.org/en/latest/customize.html#inifiles>`_:
+
+::
+
+    [pytest]
+    spec_header_format = {path}:{class_name}
+
+In addition to the ``{path}`` and ``{class_name}`` replacement fields, there is also ``{test_case}`` that holds a more human readable name.
+
+``spec_test_format``
+--------------------
+
+You can configure the format of the test results by specifying a `format string <https://docs.python.org/2/library/string.html#format-string-syntax>`_ in your `ini-file <http://doc.pytest.org/en/latest/customize.html#inifiles>`_:
+
+::
+
+    [pytest]
+    spec_test_format = [{result}]  {name}
+
+
 Continuous Integration
 ======================
 .. image:: https://drone.io/github.com/pchomik/pytest-spec/status.png

--- a/pytest_spec/patch.py
+++ b/pytest_spec/patch.py
@@ -105,13 +105,13 @@ def _get_test_name(nodeid):
 
 def _format_results(report):
     if report.passed:
-        return {'green': True}, '[PASS]  '
+        return {'green': True}, 'PASS'
     elif report.failed:
-        return {'red': True}, '[FAIL]  '
+        return {'red': True}, 'FAIL'
     elif report.skipped:
-        return {'yellow': True}, '[SKIP]  '
+        return {'yellow': True}, 'SKIP'
 
 
 def _print_test_result(self, test_name, test_status, markup):
     self._tw.line()
-    self._tw.write("    {0}{1}".format(test_status, test_name), **markup)
+    self._tw.write("    "+self.config.getini('spec_test_format').format(result=test_status, name=test_name), **markup)

--- a/pytest_spec/patch.py
+++ b/pytest_spec/patch.py
@@ -27,7 +27,7 @@ def pytest_runtest_logreport(self, report):
         return
     if not _is_nodeid_has_test(report.nodeid):
         return
-    test_path = _get_test_path(report.nodeid)
+    test_path = _get_test_path(report.nodeid, self.config.getini('spec_header_format'))
     if test_path != self.currentfspath:
         self.currentfspath = test_path
         _print_class_information(self)
@@ -43,12 +43,18 @@ def _is_nodeid_has_test(nodeid):
     return False
 
 
-def _get_test_path(nodeid):
+def _get_test_path(nodeid, header):
     levels = nodeid.split("::")
+
     if len(levels) > 2:
-        return _split_words(_remove_class_prefix(levels[1]))
+        path = levels[0]
+        name = _split_words(_remove_class_prefix(levels[1]))
     else:
-        return _capitalize_first_letter(_replace_underscores(_remove_test_prefix(_remove_file_extension(levels[0]))))
+        dirs, file = os.path.split(levels[0])
+        path = dirs or '.'
+        name = _capitalize_first_letter(_replace_underscores(_remove_test_prefix(_remove_file_extension(file))))
+
+    return header.format(path=path, name=name)
 
 
 def _print_class_information(self):

--- a/pytest_spec/patch.py
+++ b/pytest_spec/patch.py
@@ -47,14 +47,14 @@ def _get_test_path(nodeid, header):
     levels = nodeid.split("::")
 
     if len(levels) > 2:
-        path = levels[0]
-        name = _split_words(_remove_class_prefix(levels[1]))
+        class_name = levels[1]
+        test_case = _split_words(_remove_class_prefix(class_name))
     else:
-        dirs, file = os.path.split(levels[0])
-        path = dirs or '.'
-        name = _capitalize_first_letter(_replace_underscores(_remove_test_prefix(_remove_file_extension(file))))
+        module_name = os.path.split(levels[0])[1]
+        class_name = ''
+        test_case = _capitalize_first_letter(_replace_underscores(_remove_test_prefix(_remove_file_extension(module_name))))
 
-    return header.format(path=path, name=name)
+    return header.format(path=levels[0], class_name=class_name, test_case=test_case)
 
 
 def _print_class_information(self):

--- a/pytest_spec/patch.py
+++ b/pytest_spec/patch.py
@@ -4,6 +4,7 @@
 :author: Pawel Chomicki
 """
 
+import os
 import re
 
 
@@ -43,7 +44,11 @@ def _is_nodeid_has_test(nodeid):
 
 
 def _get_test_path(nodeid):
-    return nodeid.rsplit("::", 1)[0]
+    levels = nodeid.split("::")
+    if len(levels) > 2:
+        return _split_words(_remove_class_prefix(levels[1]))
+    else:
+        return _capitalize_first_letter(_replace_underscores(_remove_test_prefix(_remove_file_extension(levels[0]))))
 
 
 def _print_class_information(self):
@@ -52,6 +57,18 @@ def _print_class_information(self):
     self._tw.line()
     self._tw.write(self.currentfspath)
     self._first_triggered = True
+
+
+def _remove_class_prefix(nodeid):
+    return re.sub("^Test", "", nodeid)
+
+
+def _split_words(nodeid):
+    return re.sub(r"([A-Z])", r" \1", nodeid).strip()
+
+
+def _remove_file_extension(nodeid):
+    return os.path.splitext(nodeid)[0]
 
 
 def _remove_module_name(nodeid):

--- a/pytest_spec/plugin.py
+++ b/pytest_spec/plugin.py
@@ -18,13 +18,13 @@ def pytest_addoption(parser):
     # register config options
     parser.addini(
         'spec_header_format',
-        default='{path}:{name}',
-        help='The format of the test case when using the spec plugin'
+        default='{path}:{class_name}',
+        help='The format of the test headers when using the spec plugin'
     )
     parser.addini(
         'spec_test_format',
         default='[{result}]  {name}',
-        help='The format of the test result when using the spec plugin'
+        help='The format of the test results when using the spec plugin'
     )
 
 

--- a/pytest_spec/plugin.py
+++ b/pytest_spec/plugin.py
@@ -21,6 +21,11 @@ def pytest_addoption(parser):
         default='{path}:{name}',
         help='The format of the test case when using the spec plugin'
     )
+    parser.addini(
+        'spec_test_format',
+        default='[{result}]  {name}',
+        help='The format of the test result when using the spec plugin'
+    )
 
 
 def pytest_configure(config):

--- a/pytest_spec/plugin.py
+++ b/pytest_spec/plugin.py
@@ -15,6 +15,13 @@ def pytest_addoption(parser):
         help='Print test result in specification format'
     )
 
+    # register config options
+    parser.addini(
+        'spec_header_format',
+        default='{path}:{name}',
+        help='The format of the test case when using the spec plugin'
+    )
+
 
 def pytest_configure(config):
     if config.option.spec:


### PR DESCRIPTION
This PR beautifies the displayed class information.

For test _methods_, it shows the name of their test class without the `Test` prefix and split into individual words on uppercase letters.

For test _functions_, it shows the name of the test module, stripped of its file extension and otherwise normalized like a test name.

Addresses #10.
