### PR TITLE
Handle tests/specs with nested scopes

### DIFF
--- a/pytest_spec/patch.py
+++ b/pytest_spec/patch.py
@@ -173,11 +173,11 @@ def _get_test_name(nodeid):
 
 
 def _format_results(report, config):
-    success_glpyh = config.getini('spec_success_indicator')
+    success_indicator = config.getini('spec_success_indicator')
     failure_indicator = config.getini('spec_failure_indicator')
     skipped_indicator = config.getini('spec_skipped_indicator')
     if report.passed:
-        return {'green': True}, success_glpyh
+        return {'green': True}, success_indicator
     elif report.failed:
         return {'red': True}, failure_indicator
     elif report.skipped:

--- a/pytest_spec/patch.py
+++ b/pytest_spec/patch.py
@@ -39,7 +39,7 @@ def get_report_scopes(report):
     >>> get_report_scopes(report)
     ['describe_a_user', 'describe_email_address']
     """
-    return report.nodeid.split('::')[1:-1]
+    return [i for i in report.nodeid.split('::')[1:-1] if i != '()']
 
 
 def pytest_runtest_logreport(self, report):

--- a/pytest_spec/patch.py
+++ b/pytest_spec/patch.py
@@ -53,6 +53,7 @@ def pytest_runtest_logreport(self, report):
     """
     self.previous_scopes = getattr(self, 'previous_scopes', [])
     self.current_scopes = get_report_scopes(report)
+    indent = self.config.getini('spec_indent')
 
     res = self.config.hook.pytest_report_teststatus(report=report)
     cat, letter, word = res
@@ -68,7 +69,7 @@ def pytest_runtest_logreport(self, report):
 
     if self.previous_scopes != self.current_scopes:
         msg = [i for i in self.current_scopes if i not in self.previous_scopes]
-        msg = [' ' * 4 * ind + prettify_description(item)
+        msg = [indent * ind + prettify_description(item)
                for ind, item in enumerate(msg, len(self.current_scopes) - 1)]
         msg = "\n".join(msg)
         if msg:
@@ -185,9 +186,10 @@ def _format_results(report, config):
 
 
 def _print_test_result(self, test_name, test_status, markup, depth):
+    indent = self.config.getini('spec_indent')
     self._tw.line()
     self._tw.write(
-        "    " * depth + self.config.getini('spec_test_format').format(
+        indent * depth + self.config.getini('spec_test_format').format(
             result=test_status, name=test_name
         ), **markup
     )

--- a/pytest_spec/patch.py
+++ b/pytest_spec/patch.py
@@ -20,6 +20,7 @@ def pytest_runtest_logstart(self, nodeid, location):
 def pytest_collection_modifyitems(session, config, items):
     def depth(f):
         return len(f.listchain()) - 1
+
     def get_module_name(f):
         return f.listchain()[1].name
     items.sort(key=depth)
@@ -67,8 +68,7 @@ def pytest_runtest_logreport(self, report):
     if self.previous_scopes != self.current_scopes:
         msg = [i for i in self.current_scopes if i not in self.previous_scopes]
         msg = [' ' * 4 * ind + prettify_description(item)
-            for ind, item in enumerate(msg, len(self.current_scopes) - 1)
-        ]
+               for ind, item in enumerate(msg, len(self.current_scopes) - 1)]
         msg = "\n".join(msg)
         _print_description(self, msg)
         self.previous_scopes = self.current_scopes
@@ -87,10 +87,9 @@ def _is_nodeid_has_test(nodeid):
 
 def prettify(string):
     return _capitalize_first_letter(
-           _replace_underscores(
-           _remove_test_container_prefix(
-           _remove_file_extension(string)
-    )))
+        _replace_underscores(
+            _remove_test_container_prefix(
+                _remove_file_extension(string))))
 
 
 def prettify_test(string):

--- a/pytest_spec/patch.py
+++ b/pytest_spec/patch.py
@@ -11,15 +11,48 @@ import re
 def pytest_runtest_logstart(self, nodeid, location):
     """Signal the start of running a single test item.
 
-    Hook has to be disabled because additional information may break output formatting.
+    Hook has to be disabled because additional information may break output
+    formatting.
     """
+    pass
+
+
+def pytest_collection_modifyitems(session, config, items):
+    def depth(f):
+        return len(f.listchain()) - 1
+    def get_module_name(f):
+        return f.listchain()[1].name
+    items.sort(key=depth)
+    items.sort(key=get_module_name)
+    return items
+
+
+def get_report_scopes(report):
+    """
+    Returns a list of the report's nested scopes, excluding the module.
+
+    >>> report = lambda s: s
+    >>> report.nodeid = (
+        "specs/user.py::describe_a_user::"
+        "describe_email_address::cannot_be_hotmail"
+    )
+    >>> get_report_scopes(report)
+    ['describe_a_user', 'describe_email_address']
+    """
+    return report.nodeid.split('::')[1:-1]
 
 
 def pytest_runtest_logreport(self, report):
-    """Process a test setup/call/teardown report relating to the respective phase of executing a test.
-
-    Hook changed to define SPECIFICATION like output format. This hook will overwrite also VERBOSE option.
     """
+    Process a test setup/call/teardown report relating to the respective phase
+    of executing a test.
+
+    Hook changed to define SPECIFICATION like output format. This hook will
+    overwrite also VERBOSE option.
+    """
+    self.previous_scopes = getattr(self, 'previous_scopes', [])
+    self.current_scopes = get_report_scopes(report)
+
     res = self.config.hook.pytest_report_teststatus(report=report)
     cat, letter, word = res
     self.stats.setdefault(cat, []).append(report)
@@ -30,11 +63,20 @@ def pytest_runtest_logreport(self, report):
     test_path = _get_test_path(report.nodeid, self.config.getini('spec_header_format'))
     if test_path != self.currentfspath:
         self.currentfspath = test_path
-        _print_class_information(self)
+
+    if self.previous_scopes != self.current_scopes:
+        msg = [i for i in self.current_scopes if i not in self.previous_scopes]
+        msg = [' ' * 4 * ind + prettify_description(item)
+            for ind, item in enumerate(msg, len(self.current_scopes) - 1)
+        ]
+        msg = "\n".join(msg)
+        _print_description(self, msg)
+        self.previous_scopes = self.current_scopes
     if not isinstance(word, tuple):
         test_name = _get_test_name(report.nodeid)
         markup, test_status = _format_results(report)
-        _print_test_result(self, test_name, test_status, markup)
+        depth = len(self.current_scopes)
+        _print_test_result(self, test_name, test_status, markup, depth)
 
 
 def _is_nodeid_has_test(nodeid):
@@ -43,34 +85,52 @@ def _is_nodeid_has_test(nodeid):
     return False
 
 
+def prettify(string):
+    return _capitalize_first_letter(
+           _replace_underscores(
+           _remove_test_container_prefix(
+           _remove_file_extension(string)
+    )))
+
+
+def prettify_test(string):
+    return prettify(_remove_test_prefix(string))
+
+
+def prettify_description(string):
+    return prettify(_append_colon(_remove_test_container_prefix(string)))
+
+
 def _get_test_path(nodeid, header):
     levels = nodeid.split("::")
 
     if len(levels) > 2:
         class_name = levels[1]
-        test_case = _split_words(_remove_class_prefix(class_name))
+        test_case = prettify(class_name)
     else:
         module_name = os.path.split(levels[0])[1]
         class_name = ''
-        test_case = _capitalize_first_letter(_replace_underscores(_remove_test_prefix(_remove_file_extension(module_name))))
+        test_case = prettify(module_name)
 
-    return header.format(path=levels[0], class_name=class_name, test_case=test_case)
+    return header.format(
+        path=levels[0],
+        class_name=class_name,
+        test_case=test_case
+    )
 
 
-def _print_class_information(self):
+def _print_description(self, msg=None):
+    if not msg:
+        msg = self.currentfspath
     if hasattr(self, '_first_triggered'):
         self._tw.line()
     self._tw.line()
-    self._tw.write(self.currentfspath)
+    self._tw.write(msg)
     self._first_triggered = True
 
 
-def _remove_class_prefix(nodeid):
-    return re.sub("^Test", "", nodeid)
-
-
-def _split_words(nodeid):
-    return re.sub(r"([A-Z])", r" \1", nodeid).strip()
+def _remove_test_container_prefix(nodeid):
+    return re.sub("^(Test)|(describe)", "", nodeid)
 
 
 def _remove_file_extension(nodeid):
@@ -93,8 +153,12 @@ def _capitalize_first_letter(s):
     return s[:1].capitalize() + s[1:]
 
 
+def _append_colon(string):
+    return "{}:".format(string)
+
+
 def _get_test_name(nodeid):
-    test_name = _capitalize_first_letter(_replace_underscores(_remove_test_prefix(_remove_module_name(nodeid))))
+    test_name = prettify_test(_remove_module_name(nodeid))
     if test_name[:1] is ' ':
         test_name_parts = test_name.split('  ')
         if len(test_name_parts) == 1:
@@ -112,6 +176,10 @@ def _format_results(report):
         return {'yellow': True}, 'SKIP'
 
 
-def _print_test_result(self, test_name, test_status, markup):
+def _print_test_result(self, test_name, test_status, markup, depth):
     self._tw.line()
-    self._tw.write("    "+self.config.getini('spec_test_format').format(result=test_status, name=test_name), **markup)
+    self._tw.write(
+        "    " * depth + self.config.getini('spec_test_format').format(
+            result=test_status, name=test_name
+        ), **markup
+    )

--- a/pytest_spec/patch.py
+++ b/pytest_spec/patch.py
@@ -74,7 +74,7 @@ def pytest_runtest_logreport(self, report):
         self.previous_scopes = self.current_scopes
     if not isinstance(word, tuple):
         test_name = _get_test_name(report.nodeid)
-        markup, test_status = _format_results(report)
+        markup, test_status = _format_results(report, self.config)
         depth = len(self.current_scopes)
         _print_test_result(self, test_name, test_status, markup, depth)
 
@@ -166,13 +166,16 @@ def _get_test_name(nodeid):
     return test_name
 
 
-def _format_results(report):
+def _format_results(report, config):
+    success_glpyh = config.getini('spec_success_indicator')
+    failure_indicator = config.getini('spec_failure_indicator')
+    skipped_indicator = config.getini('spec_skipped_indicator')
     if report.passed:
-        return {'green': True}, 'PASS'
+        return {'green': True}, success_glpyh
     elif report.failed:
-        return {'red': True}, 'FAIL'
+        return {'red': True}, failure_indicator
     elif report.skipped:
-        return {'yellow': True}, 'SKIP'
+        return {'yellow': True}, skipped_indicator
 
 
 def _print_test_result(self, test_name, test_status, markup, depth):

--- a/pytest_spec/patch.py
+++ b/pytest_spec/patch.py
@@ -64,13 +64,15 @@ def pytest_runtest_logreport(self, report):
     test_path = _get_test_path(report.nodeid, self.config.getini('spec_header_format'))
     if test_path != self.currentfspath:
         self.currentfspath = test_path
+        _print_description(self)
 
     if self.previous_scopes != self.current_scopes:
         msg = [i for i in self.current_scopes if i not in self.previous_scopes]
         msg = [' ' * 4 * ind + prettify_description(item)
                for ind, item in enumerate(msg, len(self.current_scopes) - 1)]
         msg = "\n".join(msg)
-        _print_description(self, msg)
+        if msg:
+            _print_description(self, msg)
         self.previous_scopes = self.current_scopes
     if not isinstance(word, tuple):
         test_name = _get_test_name(report.nodeid)
@@ -103,23 +105,27 @@ def prettify_description(string):
 def _get_test_path(nodeid, header):
     levels = nodeid.split("::")
 
+    module_path = levels[0]
+    module_name = os.path.split(levels[0])[1]
+
     if len(levels) > 2:
         class_name = levels[1]
         test_case = prettify(class_name)
     else:
-        module_name = os.path.split(levels[0])[1]
         class_name = ''
         test_case = prettify(module_name)
 
     return header.format(
         path=levels[0],
+        module_name=module_name,
+        module_path=module_path,
         class_name=class_name,
         test_case=test_case
     )
 
 
 def _print_description(self, msg=None):
-    if not msg:
+    if msg is None:
         msg = self.currentfspath
     if hasattr(self, '_first_triggered'):
         self._tw.line()

--- a/pytest_spec/plugin.py
+++ b/pytest_spec/plugin.py
@@ -41,6 +41,11 @@ def pytest_addoption(parser):
         default='?',
         help='The indicator displayed when a test is skipped.'
     )
+    parser.addini(
+        'spec_indent',
+        default='    ',
+        help='The string used for indentation in the spec output.'
+    )
 
 
 def pytest_configure(config):

--- a/pytest_spec/plugin.py
+++ b/pytest_spec/plugin.py
@@ -18,7 +18,7 @@ def pytest_addoption(parser):
     # register config options
     parser.addini(
         'spec_header_format',
-        default='{path}::{class_name}',
+        default='{module_path}:',
         help='The format of the test headers when using the spec plugin'
     )
     parser.addini(

--- a/pytest_spec/plugin.py
+++ b/pytest_spec/plugin.py
@@ -23,22 +23,22 @@ def pytest_addoption(parser):
     )
     parser.addini(
         'spec_test_format',
-        default='[{result}]  {name}',
+        default='{result} {name}',
         help='The format of the test results when using the spec plugin'
     )
     parser.addini(
         'spec_success_indicator',
-        default='PASS',
+        default='✓',
         help='The indicator displayed when a test passes.'
     )
     parser.addini(
         'spec_failure_indicator',
-        default='FAIL',
+        default='✗',
         help='The indicator displayed when a test fails.'
     )
     parser.addini(
         'spec_skipped_indicator',
-        default='SKIP',
+        default='?',
         help='The indicator displayed when a test is skipped.'
     )
 

--- a/pytest_spec/plugin.py
+++ b/pytest_spec/plugin.py
@@ -26,6 +26,21 @@ def pytest_addoption(parser):
         default='[{result}]  {name}',
         help='The format of the test results when using the spec plugin'
     )
+    parser.addini(
+        'spec_success_indicator',
+        default='PASS',
+        help='The indicator displayed when a test passes.'
+    )
+    parser.addini(
+        'spec_failure_indicator',
+        default='FAIL',
+        help='The indicator displayed when a test fails.'
+    )
+    parser.addini(
+        'spec_skipped_indicator',
+        default='SKIP',
+        help='The indicator displayed when a test is skipped.'
+    )
 
 
 def pytest_configure(config):

--- a/pytest_spec/plugin.py
+++ b/pytest_spec/plugin.py
@@ -5,6 +5,7 @@
 """
 from .replacer import logstart_replacer, report_replacer, modifyitems_replacer
 
+
 def pytest_addoption(parser):
     group = parser.getgroup('general')
     group.addoption(

--- a/pytest_spec/plugin.py
+++ b/pytest_spec/plugin.py
@@ -43,7 +43,7 @@ def pytest_addoption(parser):
     )
     parser.addini(
         'spec_indent',
-        default='    ',
+        default='  ',
         help='The string used for indentation in the spec output.'
     )
 

--- a/pytest_spec/plugin.py
+++ b/pytest_spec/plugin.py
@@ -3,8 +3,7 @@
 
 :author: Pawel Chomicki
 """
-from .replacer import logstart_replacer, report_replacer
-
+from .replacer import logstart_replacer, report_replacer, modifyitems_replacer
 
 def pytest_addoption(parser):
     group = parser.getgroup('general')
@@ -34,4 +33,5 @@ def pytest_configure(config):
         import _pytest
         _pytest.terminal.TerminalReporter.pytest_runtest_logstart = logstart_replacer
         _pytest.terminal.TerminalReporter.pytest_runtest_logreport = report_replacer
+        _pytest.terminal.TerminalReporter.pytest_collection_modifyitems = modifyitems_replacer
         imp.reload(_pytest)

--- a/pytest_spec/plugin.py
+++ b/pytest_spec/plugin.py
@@ -29,22 +29,22 @@ def pytest_addoption(parser):
     parser.addini(
         'spec_success_indicator',
         default='✓',
-        help='The indicator displayed when a test passes.'
+        help='The indicator displayed when a test passes'
     )
     parser.addini(
         'spec_failure_indicator',
         default='✗',
-        help='The indicator displayed when a test fails.'
+        help='The indicator displayed when a test fails'
     )
     parser.addini(
         'spec_skipped_indicator',
         default='?',
-        help='The indicator displayed when a test is skipped.'
+        help='The indicator displayed when a test is skipped'
     )
     parser.addini(
         'spec_indent',
         default='  ',
-        help='The string used for indentation in the spec output.'
+        help='The string used for indentation in the spec output'
     )
 
 

--- a/pytest_spec/replacer.py
+++ b/pytest_spec/replacer.py
@@ -1,11 +1,16 @@
 # -*- coding: utf-8 -*-
 """Module contains method for replace operation.
 
-Additional method are necessary because self is not yet defined and module doesn't have access to it.
+Additional method are necessary because self is not yet defined and module
+doesn't have access to it.
 
 :author: Pawel Chomicki
 """
-from .patch import pytest_runtest_logstart, pytest_runtest_logreport
+from .patch import (
+    pytest_runtest_logstart,
+    pytest_runtest_logreport,
+    pytest_collection_modifyitems
+)
 
 
 def logstart_replacer(self, nodeid, location):
@@ -17,4 +22,10 @@ def logstart_replacer(self, nodeid, location):
 def report_replacer(self, report):
     def wrapper():
         return pytest_runtest_logreport(self, report)
+    return wrapper()
+
+
+def modifyitems_replacer(session, config, items):
+    def wrapper():
+        return pytest_collection_modifyitems(session, config, items)
     return wrapper()

--- a/test/test_patch.py
+++ b/test/test_patch.py
@@ -29,7 +29,7 @@ class FakeConfig(object):
             'spec_success_indicator': '✓',
             'spec_failure_indicator': '✗',
             'spec_skipped_indicator': '?',
-            'spec_indent': '    ',
+            'spec_indent': '  ',
         }
         result = mapping.get(option, None)
         if not result:
@@ -86,7 +86,7 @@ class TestPatch(unittest.TestCase):
         pytest_runtest_logreport(fake_self, FakeReport('Test::Second::test_example_demo'))
         fake_self._tw.write.assert_has_calls([
             call('Second:'),
-            call('    ✓ Example demo', green=True)
+            call('  ✓ Example demo', green=True)
         ])
 
     def test__pytest_runtest_logreport__prints_test_name_and_failed_status(self):
@@ -94,7 +94,7 @@ class TestPatch(unittest.TestCase):
         pytest_runtest_logreport(fake_self, FakeReport('Test::Second::test_example_demo', passed=False, failed=True))
         fake_self._tw.write.assert_has_calls([
             call('Second:'),
-            call('    ✗ Example demo', red=True)
+            call('  ✗ Example demo', red=True)
         ])
 
     def test__pytest_runtest_logreport__prints_test_name_and_skipped_status(self):
@@ -102,7 +102,7 @@ class TestPatch(unittest.TestCase):
         pytest_runtest_logreport(fake_self, FakeReport('Test::Second::test_example_demo', passed=False, skipped=True))
         fake_self._tw.write.assert_has_calls([
             call('Second:'),
-            call('    ? Example demo', yellow=True)
+            call('  ? Example demo', yellow=True)
         ])
 
     def test__pytest_runtest_logreport__skips_empty_line_for_first_test(self):
@@ -116,7 +116,7 @@ class TestPatch(unittest.TestCase):
         pytest_runtest_logreport(fake_self, FakeReport('Test::Second::test__example__demo'))
         fake_self._tw.write.assert_has_calls([
             call('Second:'),
-            call('    ✓ Example demo', green=True)
+            call('  ✓ Example demo', green=True)
         ])
 
     def test__pytest_runtest_logreport__prints_test_name_and_handle_only_single_marker(self):
@@ -124,7 +124,7 @@ class TestPatch(unittest.TestCase):
         pytest_runtest_logreport(fake_self, FakeReport('Test::Second::test__example'))
         fake_self._tw.write.assert_has_calls([
             call('Second:'),
-            call('    ✓ Example', green=True)
+            call('  ✓ Example', green=True)
         ])
 
     def test__pytest_runtest_logreport__honors_capitalization_of_words_in_test_name(self):
@@ -132,7 +132,7 @@ class TestPatch(unittest.TestCase):
         pytest_runtest_logreport(fake_self, FakeReport('Test::Second::test_example_Demo_CamelCase'))
         fake_self._tw.write.assert_has_calls([
             call('Second:'),
-            call('    ✓ Example Demo CamelCase', green=True)
+            call('  ✓ Example Demo CamelCase', green=True)
         ])
 
 

--- a/test/test_patch.py
+++ b/test/test_patch.py
@@ -29,6 +29,7 @@ class FakeConfig(object):
             'spec_success_indicator': '✓',
             'spec_failure_indicator': '✗',
             'spec_skipped_indicator': '?',
+            'spec_indent': '    ',
         }
         result = mapping.get(option, None)
         if not result:

--- a/test/test_patch.py
+++ b/test/test_patch.py
@@ -25,10 +25,10 @@ class FakeConfig(object):
     def getini(self, option):
         mapping = {
             'spec_header_format': '{path}::{class_name}',
-            'spec_test_format': '[{result}]  {name}',
-            'spec_success_indicator': 'PASS',
-            'spec_failure_indicator': 'FAIL',
-            'spec_skipped_indicator': 'SKIP',
+            'spec_test_format': '{result} {name}',
+            'spec_success_indicator': '✓',
+            'spec_failure_indicator': '✗',
+            'spec_skipped_indicator': '?',
         }
         result = mapping.get(option, None)
         if not result:
@@ -83,17 +83,26 @@ class TestPatch(unittest.TestCase):
     def test__pytest_runtest_logreport__prints_test_name_and_passed_status(self):
         fake_self = FakeSelf()
         pytest_runtest_logreport(fake_self, FakeReport('Test::Second::test_example_demo'))
-        fake_self._tw.write.assert_has_calls([call('    [PASS]  Example demo', green=True)])
+        fake_self._tw.write.assert_has_calls([
+            call('Second:'),
+            call('    ✓ Example demo', green=True)
+        ])
 
     def test__pytest_runtest_logreport__prints_test_name_and_failed_status(self):
         fake_self = FakeSelf()
         pytest_runtest_logreport(fake_self, FakeReport('Test::Second::test_example_demo', passed=False, failed=True))
-        fake_self._tw.write.assert_has_calls([call('    [FAIL]  Example demo', red=True)])
+        fake_self._tw.write.assert_has_calls([
+            call('Second:'),
+            call('    ✗ Example demo', red=True)
+        ])
 
     def test__pytest_runtest_logreport__prints_test_name_and_skipped_status(self):
         fake_self = FakeSelf()
         pytest_runtest_logreport(fake_self, FakeReport('Test::Second::test_example_demo', passed=False, skipped=True))
-        fake_self._tw.write.assert_has_calls([call('    [SKIP]  Example demo', yellow=True)])
+        fake_self._tw.write.assert_has_calls([
+            call('Second:'),
+            call('    ? Example demo', yellow=True)
+        ])
 
     def test__pytest_runtest_logreport__skips_empty_line_for_first_test(self):
         fake_self = FakeSelf()
@@ -104,17 +113,26 @@ class TestPatch(unittest.TestCase):
     def test__pytest_runtest_logreport__marks_method_marked_by_double_underscores(self):
         fake_self = FakeSelf()
         pytest_runtest_logreport(fake_self, FakeReport('Test::Second::test__example__demo'))
-        fake_self._tw.write.assert_has_calls([call('    [PASS]  Example demo', green=True)])
+        fake_self._tw.write.assert_has_calls([
+            call('Second:'),
+            call('    ✓ Example demo', green=True)
+        ])
 
     def test__pytest_runtest_logreport__prints_test_name_and_handle_only_single_marker(self):
         fake_self = FakeSelf()
         pytest_runtest_logreport(fake_self, FakeReport('Test::Second::test__example'))
-        fake_self._tw.write.assert_has_calls([call('    [PASS]  Example', green=True)])
+        fake_self._tw.write.assert_has_calls([
+            call('Second:'),
+            call('    ✓ Example', green=True)
+        ])
 
     def test__pytest_runtest_logreport__honors_capitalization_of_words_in_test_name(self):
         fake_self = FakeSelf()
         pytest_runtest_logreport(fake_self, FakeReport('Test::Second::test_example_Demo_CamelCase'))
-        fake_self._tw.write.assert_has_calls([call('    [PASS]  Example Demo CamelCase', green=True)])
+        fake_self._tw.write.assert_has_calls([
+            call('Second:'),
+            call('    ✓ Example Demo CamelCase', green=True)
+        ])
 
 
 if __name__ == '__main__':

--- a/test/test_patch.py
+++ b/test/test_patch.py
@@ -23,12 +23,19 @@ class FakeConfig(object):
         self.hook = FakeHook(*args, **kwargs)
 
     def getini(self, option):
-        if option == 'spec_header_format':
-            return '{path}::{class_name}'
-        elif option == 'spec_test_format':
-            return '[{result}]  {name}'
-        else:
-            raise TypeError('Option {} is not supported in the test'.format(option))
+        mapping = {
+            'spec_header_format': '{path}::{class_name}',
+            'spec_test_format': '[{result}]  {name}',
+            'spec_success_indicator': 'PASS',
+            'spec_failure_indicator': 'FAIL',
+            'spec_skipped_indicator': 'SKIP',
+        }
+        result = mapping.get(option, None)
+        if not result:
+            raise TypeError('Option {} is not supported in the test'.format(
+                option)
+            )
+        return result
 
 
 class FakeStats(object):

--- a/test/test_patch.py
+++ b/test/test_patch.py
@@ -71,7 +71,7 @@ class TestPatch(unittest.TestCase):
     def test__pytest_runtest_logreport__prints_class_name_before_first_test_result(self):
         fake_self = FakeSelf()
         pytest_runtest_logreport(fake_self, FakeReport('Test::Second::Test_example_demo'))
-        fake_self._tw.write.assert_has_calls([call('Test::Second')])
+        fake_self._tw.write.assert_has_calls([call('Second:')])
 
     def test__pytest_runtest_logreport__prints_test_name_and_passed_status(self):
         fake_self = FakeSelf()

--- a/test/test_patch.py
+++ b/test/test_patch.py
@@ -24,7 +24,7 @@ class FakeConfig(object):
 
     def getini(self, option):
         mapping = {
-            'spec_header_format': '{path}::{class_name}',
+            'spec_header_format': '{module_path}:',
             'spec_test_format': '{result} {name}',
             'spec_success_indicator': '✓',
             'spec_failure_indicator': '✗',


### PR DESCRIPTION
This pull request produces better spec output for tests/specs with nested scopes, e.g.

```python
# pytest-describe/bdd style:
def describe_some_api():

    def a_thing():
        assert True

    def describe_filtering():

        def it_works():
            assert True

        def describe_specific_filter():

            def it_also_works():
                assert True

# class style, with nested classes:
class TestSomeApi:

    def test_a_thing(self):
        assert True

    class TestFiltering:

        def test_it_works(self):
            assert True

        class TestSpecificFilter:

            def test_it_also_works(self):
                assert True
```

Now results in this output:
```
Some Api:
    [PASS] A thing

    Filtering:
        [PASS] It works

        Specific Filter:
            [PASS] It also works
```

Previously it would produce:
```
some/path/to/test.py::describe_some_api
    [PASS] A thing
    [PASS] It works
    [PASS] It also works
```

The only information lost is the spec_header_format, which by default includes the path to the module/component under test, but that could be reintroduced. Let me know what your thoughts are, Pawel!