### PR TITLE
New section name in setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,2 @@
-[pytest]
+[tool:pytest]
 pep8maxlinelength=150


### PR DESCRIPTION
Fixes the error: Failed: [pytest] section in setup.cfg files is no longer supported, change to [tool:pytest] instead.

Complete traceback:
```
$ python3.7 -m pytest test
Traceback (most recent call last):
  File "/usr/lib64/python3.7/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/usr/lib64/python3.7/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/home/lbalhar/.virtualenvs/pytest-spec/lib/python3.7/site-packages/pytest.py", line 89, in <module>
    raise SystemExit(pytest.main())
  File "/home/lbalhar/.virtualenvs/pytest-spec/lib/python3.7/site-packages/_pytest/config/__init__.py", line 60, in main
    config = _prepareconfig(args, plugins)
  File "/home/lbalhar/.virtualenvs/pytest-spec/lib/python3.7/site-packages/_pytest/config/__init__.py", line 201, in _prepareconfig
    pluginmanager=pluginmanager, args=args
  File "/home/lbalhar/.virtualenvs/pytest-spec/lib/python3.7/site-packages/pluggy/hooks.py", line 289, in __call__
    return self._hookexec(self, self.get_hookimpls(), kwargs)
  File "/home/lbalhar/.virtualenvs/pytest-spec/lib/python3.7/site-packages/pluggy/manager.py", line 68, in _hookexec
    return self._inner_hookexec(hook, methods, kwargs)
  File "/home/lbalhar/.virtualenvs/pytest-spec/lib/python3.7/site-packages/pluggy/manager.py", line 62, in <lambda>
    firstresult=hook.spec.opts.get("firstresult") if hook.spec else False,
  File "/home/lbalhar/.virtualenvs/pytest-spec/lib/python3.7/site-packages/pluggy/callers.py", line 203, in _multicall
    gen.send(outcome)
  File "/home/lbalhar/.virtualenvs/pytest-spec/lib/python3.7/site-packages/_pytest/helpconfig.py", line 93, in pytest_cmdline_parse
    config = outcome.get_result()
  File "/home/lbalhar/.virtualenvs/pytest-spec/lib/python3.7/site-packages/pluggy/callers.py", line 80, in get_result
    raise ex[1].with_traceback(ex[2])
  File "/home/lbalhar/.virtualenvs/pytest-spec/lib/python3.7/site-packages/pluggy/callers.py", line 187, in _multicall
    res = hook_impl.function(*args)
  File "/home/lbalhar/.virtualenvs/pytest-spec/lib/python3.7/site-packages/_pytest/config/__init__.py", line 679, in pytest_cmdline_parse
    self.parse(args)
  File "/home/lbalhar/.virtualenvs/pytest-spec/lib/python3.7/site-packages/_pytest/config/__init__.py", line 896, in parse
    self._preparse(args, addopts=addopts)
  File "/home/lbalhar/.virtualenvs/pytest-spec/lib/python3.7/site-packages/_pytest/config/__init__.py", line 829, in _preparse
    self._initini(args)
  File "/home/lbalhar/.virtualenvs/pytest-spec/lib/python3.7/site-packages/_pytest/config/__init__.py", line 752, in _initini
    config=self,
  File "/home/lbalhar/.virtualenvs/pytest-spec/lib/python3.7/site-packages/_pytest/config/findpaths.py", line 122, in determine_setup
    rootdir, inifile, inicfg = getcfg([ancestor], config=config)
  File "/home/lbalhar/.virtualenvs/pytest-spec/lib/python3.7/site-packages/_pytest/config/findpaths.py", line 46, in getcfg
    pytrace=False,
  File "/home/lbalhar/.virtualenvs/pytest-spec/lib/python3.7/site-packages/_pytest/outcomes.py", line 116, in fail
    raise Failed(msg=msg, pytrace=pytrace)
Failed: [pytest] section in setup.cfg files is no longer supported, change to [tool:pytest] instead.
```