### PR TITLE
pass 'config' parameter to hook (fixes #21)

### DIFF
--- a/pytest_spec/patch.py
+++ b/pytest_spec/patch.py
@@ -20,7 +20,7 @@ def pytest_runtest_logreport(self, report):
 
     Hook changed to define SPECIFICATION like output format. This hook will overwrite also VERBOSE option.
     """
-    res = self.config.hook.pytest_report_teststatus(report=report)
+    res = self.config.hook.pytest_report_teststatus(report=report, config=self.config)
     cat, letter, word = res
     self.stats.setdefault(cat, []).append(report)
     if not letter and not word:


### PR DESCRIPTION
Remove UserWarning raised in newer pytest versions.