### PR TITLE
Fix pytest UserWarning

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@ language: python
 python:
   - "2.7"
   - "3.5"
+  - "3.6"
+  - "3.7"
+  - "3.8"
 install: 
   - pip install pytest pytest-pep8
   - python setup.py develop

--- a/pytest_spec/patch.py
+++ b/pytest_spec/patch.py
@@ -20,7 +20,7 @@ def pytest_runtest_logreport(self, report):
 
     Hook changed to define SPECIFICATION like output format. This hook will overwrite also VERBOSE option.
     """
-    res = self.config.hook.pytest_report_teststatus(report=report)
+    res = self.config.hook.pytest_report_teststatus(report=report, config=self.config)
     cat, letter, word = res
     self.stats.setdefault(cat, []).append(report)
     if not letter and not word:

--- a/pytest_spec/patch.py
+++ b/pytest_spec/patch.py
@@ -20,7 +20,11 @@ def pytest_runtest_logreport(self, report):
 
     Hook changed to define SPECIFICATION like output format. This hook will overwrite also VERBOSE option.
     """
-    res = self.config.hook.pytest_report_teststatus(report=report, config=self.config)
+    try:
+        res = self.config.hook.pytest_report_teststatus(report=report, config=self.config)
+    except TypeError:
+        # Config argument is not supported in older versions of python
+        res = self.config.hook.pytest_report_teststatus(report=report)
     cat, letter, word = res
     self.stats.setdefault(cat, []).append(report)
     if not letter and not word:

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,2 @@
-[pytest]
+[tool:pytest]
 pep8maxlinelength=150


### PR DESCRIPTION
This changes resolves the following warning:

```
pytest_spec/patch.py:23: UserWarning: Argument(s) ('config',) which are declared in the hookspec can not be found in this hook call
res = self.config.hook.pytest_report_teststatus(report=report)

-- Docs: https://docs.pytest.org/en/latest/warnings.html
```

Relevant 3rd party PR which helped me figure this out:
https://github.com/ansible/pytest-mp/pull/17