### PR TITLE
Add logic to use test docstring instead of test name

### DIFF
--- a/pytest_spec/patch.py
+++ b/pytest_spec/patch.py
@@ -3,7 +3,6 @@
 
 :author: Pawel Chomicki
 """
-
 import os
 import re
 
@@ -80,9 +79,11 @@ def pytest_runtest_logreport(self, report):
 
     if not isinstance(word, tuple):
         test_name = _get_test_name(report.nodeid)
+        docstring_summary = getattr(report, 'docstring_summary', "")
+        docstring_summary = docstring_summary if docstring_summary else test_name
         markup, test_status = _format_results(report, self.config)
         depth = len(self.current_scopes)
-        _print_test_result(self, test_name, test_status, markup, depth)
+        _print_test_result(self, test_name, docstring_summary, test_status, markup, depth)
 
 
 def _is_nodeid_has_test(nodeid):
@@ -188,11 +189,11 @@ def _format_results(report, config):
         return {'yellow': True}, skipped_indicator
 
 
-def _print_test_result(self, test_name, test_status, markup, depth):
+def _print_test_result(self, test_name, docstring_summary, test_status, markup, depth):
     indent = self.config.getini('spec_indent')
     self._tw.line()
     self._tw.write(
         indent * depth + self.config.getini('spec_test_format').format(
-            result=test_status, name=test_name
+            result=test_status, name=test_name, docstring_summary=docstring_summary
         ), **markup
     )

--- a/pytest_spec/plugin.py
+++ b/pytest_spec/plugin.py
@@ -3,6 +3,8 @@
 
 :author: Pawel Chomicki
 """
+import pytest
+
 from .replacer import logstart_replacer, report_replacer, modifyitems_replacer
 
 
@@ -56,3 +58,12 @@ def pytest_configure(config):
         _pytest.terminal.TerminalReporter.pytest_runtest_logreport = report_replacer
         _pytest.terminal.TerminalReporter.pytest_collection_modifyitems = modifyitems_replacer
         six.moves.reload_module(_pytest)
+
+
+@pytest.mark.hookwrapper
+def pytest_runtest_makereport(item, call):
+    outcome = yield
+    report = outcome.get_result()
+    node = getattr(item, 'obj', None)
+    if node and item.obj.__doc__:
+        report.docstring_summary = str(item.obj.__doc__).split("\n")[0].strip()

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,4 @@
 [tool:pytest]
 addopts=--flake8 --spec --cov=pytest_spec --cov-report=term-missing
 flake8-max-line-length=150
+spec_test_format={result} {docstring_summary}

--- a/test/test_formats/test_describe_format.py
+++ b/test/test_formats/test_describe_format.py
@@ -19,6 +19,10 @@ def describe_first_level():
     def it_failed_on_first_level():
         assert True is False
 
+    def it_passed_with_custom_message_on_first_level():
+        """Shows custom message from docstring summary"""
+        assert True is True
+
     def describe_second_level():
 
         def it_passed_on_second_level():
@@ -32,6 +36,10 @@ def describe_first_level():
         def it_failed_on_second_level():
             assert True is False
 
+        def it_passed_with_custom_message_on_second_level():
+            """Shows custom message from docstring summary"""
+            assert True is True
+
         def describe_third_level():
 
             def it_passed_on_third_level():
@@ -44,6 +52,10 @@ def describe_first_level():
             @unittest.skip('Remove docorator to see fail result')
             def it_failed_on_third_level():
                 assert True is False
+
+            def it_passed_with_custom_message_on_third_level():
+                """Shows custom message from docstring summary"""
+                assert True is True
 
     def describe_second_level_again():
 

--- a/test/test_formats/test_functions.py
+++ b/test/test_formats/test_functions.py
@@ -11,6 +11,7 @@ def some_function(arg):
 
 
 def test__some_function__returns_none():
+    """Some func"""
     assert some_function(None) is None
 
 
@@ -19,6 +20,11 @@ def test_some_function__single_underscore_as_prefix():
 
 
 def test__some_function_single_underscore_as_suffix():
+    assert some_function(None) is None
+
+
+def test_with_custom_description():
+    """Shows custom message from docstring summary"""
     assert some_function(None) is None
 
 

--- a/test/test_formats/test_methods.py
+++ b/test/test_formats/test_methods.py
@@ -21,6 +21,10 @@ class TestFormats(unittest.TestCase):
     def test__some_method_single_underscore_as_suffix(self):
         assert SomeClass().some_method(None) is None
 
+    def test_with_custom_message(self):
+        """Shows custom message from docstring summary"""
+        assert SomeClass().some_method(None) is None
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
User will get ability to use `docstring_summary` variable in `spec_test_format`. In case test doesn't contain docstring or has empty docstring the test name will be used. 

Related to #19 