### PR TITLE
Change default skip symbol

### DIFF
--- a/pytest_spec/plugin.py
+++ b/pytest_spec/plugin.py
@@ -40,7 +40,7 @@ def pytest_addoption(parser):
     )
     parser.addini(
         'spec_skipped_indicator',
-        default='?',
+        default='»',
         help='The indicator displayed when a test is skipped'
     )
     parser.addini(


### PR DESCRIPTION
I'd like to change default skip symbol to »