### PR TITLE
Add logic to ignore some tests in spec output

### DIFF
--- a/pytest_spec/patch.py
+++ b/pytest_spec/patch.py
@@ -51,6 +51,8 @@ def pytest_runtest_logreport(self, report):
     Hook changed to define SPECIFICATION like output format. This hook will
     overwrite also VERBOSE option.
     """
+    if _is_ignored(report.nodeid, self.config.getini('spec_ignore').split(',')):
+        return
     self.previous_scopes = getattr(self, 'previous_scopes', [])
     self.current_scopes = get_report_scopes(report)
     indent = self.config.getini('spec_indent')
@@ -84,6 +86,14 @@ def pytest_runtest_logreport(self, report):
         markup, test_status = _format_results(report, self.config)
         depth = len(self.current_scopes)
         _print_test_result(self, test_name, docstring_summary, test_status, markup, depth)
+
+
+def _is_ignored(nodeid, ignore_strings):
+    if ignore_strings:
+        for ignore_string in ignore_strings:
+            if ignore_string in nodeid:
+                return True
+    return False
 
 
 def _is_nodeid_has_test(nodeid):

--- a/pytest_spec/patch.py
+++ b/pytest_spec/patch.py
@@ -51,8 +51,6 @@ def pytest_runtest_logreport(self, report):
     Hook changed to define SPECIFICATION like output format. This hook will
     overwrite also VERBOSE option.
     """
-    if _is_ignored(report.nodeid, self.config.getini('spec_ignore').split(',')):
-        return
     self.previous_scopes = getattr(self, 'previous_scopes', [])
     self.current_scopes = get_report_scopes(report)
     indent = self.config.getini('spec_indent')
@@ -60,6 +58,8 @@ def pytest_runtest_logreport(self, report):
     res = self.config.hook.pytest_report_teststatus(report=report, config=self.config)
     cat, letter, word = res
     self.stats.setdefault(cat, []).append(report)
+    if _is_ignored(report.nodeid, self.config.getini('spec_ignore').split(',')):
+        return
     if not letter and not word:
         return
     if not _is_nodeid_has_test(report.nodeid):
@@ -91,7 +91,7 @@ def pytest_runtest_logreport(self, report):
 def _is_ignored(nodeid, ignore_strings):
     if ignore_strings:
         for ignore_string in ignore_strings:
-            if ignore_string in nodeid:
+            if ignore_string and ignore_string in nodeid:
                 return True
     return False
 

--- a/pytest_spec/plugin.py
+++ b/pytest_spec/plugin.py
@@ -48,6 +48,12 @@ def pytest_addoption(parser):
         default='  ',
         help='The string used for indentation in the spec output'
     )
+    parser.addini(
+        'spec_ignore',
+        default='',
+        help='The comma-separated list of strings used to ignore tests in the spec output e.g. FLAKE8'
+    )
+
 
 
 def pytest_configure(config):

--- a/pytest_spec/plugin.py
+++ b/pytest_spec/plugin.py
@@ -55,7 +55,6 @@ def pytest_addoption(parser):
     )
 
 
-
 def pytest_configure(config):
     if getattr(config.option, 'spec', 0) and not getattr(config.option, 'quiet', 0) and not getattr(config.option, 'verbose', 0):
         import six

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,3 +2,4 @@
 addopts=--flake8 --spec --cov=pytest_spec --cov-report=term-missing
 flake8-max-line-length=150
 spec_test_format={result} {docstring_summary}
+spec_ignore=FLAKE8

--- a/test/test_patch.py
+++ b/test/test_patch.py
@@ -31,6 +31,7 @@ class FakeConfig(object):
             'spec_failure_indicator': '✗',
             'spec_skipped_indicator': '?',
             'spec_indent': '  ',
+            'spec_ignore': 'FLAKE8'
         }
 
     def getini(self, option):
@@ -160,6 +161,17 @@ class TestPatch(unittest.TestCase):
         fake_self._tw.write.assert_has_calls([
             call('  ✓ Example Demo CamelCase', green=True)
         ])
+
+    def test__pytest_runtest_logreport__ignores_nodeid_which_matches_ignore_string(self):
+        fake_self = FakeSelf()
+        pytest_runtest_logreport(fake_self, FakeReport('Test::FLAKE8'))
+        assert not fake_self._tw.write.mock_calls
+
+    def test__pytest_runtest_logreport__ignores_nodeid_if_multiple_string_ignore_are_provided(self):
+        fake_self = FakeSelf()
+        fake_self.config.mapping['spec_ignore'] = "FLAKE8,Something"
+        pytest_runtest_logreport(fake_self, FakeReport('Something'))
+        assert not fake_self._tw.write.called
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
I'd like to introduce new configuration parameter `spec_ignore`.
Parameter is a comma-separated list of strings. Plugin will use them to check if some test should be ignored in spec output or not.
This parameter can be useful to ignore FLAKE8 or ISORT tests. The result still will be available but not visible in spec output.