### PR TITLE
Add support for multiline docstrings

### DIFF
--- a/pytest_spec/plugin.py
+++ b/pytest_spec/plugin.py
@@ -71,4 +71,4 @@ def pytest_runtest_makereport(item, call):
     report = outcome.get_result()
     node = getattr(item, 'obj', None)
     if node and item.obj.__doc__:
-        report.docstring_summary = str(item.obj.__doc__).split("\n")[0].strip()
+        report.docstring_summary = str(item.obj.__doc__).lstrip().split("\n")[0].strip()

--- a/test/test_formats/test_describe_format.py
+++ b/test/test_formats/test_describe_format.py
@@ -23,6 +23,14 @@ def describe_first_level():
         """Shows custom message from docstring summary"""
         assert True is True
 
+    def it_passed_with_multiline_docstring_on_first_level():
+        """
+        Shows custom message from docstring summary
+
+        And doesn't show additional info.
+        """
+        assert True is True
+
     def describe_second_level():
 
         def it_passed_on_second_level():
@@ -40,6 +48,14 @@ def describe_first_level():
             """Shows custom message from docstring summary"""
             assert True is True
 
+        def it_passed_with_multiline_docstring_on_second_level():
+            """
+            Shows custom message from docstring summary
+
+            And doesn't show additional info.
+            """
+            assert True is True
+
         def describe_third_level():
 
             def it_passed_on_third_level():
@@ -55,6 +71,14 @@ def describe_first_level():
 
             def it_passed_with_custom_message_on_third_level():
                 """Shows custom message from docstring summary"""
+                assert True is True
+
+            def it_passed_with_multiline_docstring_on_third_level():
+                """
+                Shows custom message from docstring summary
+
+                And doesn't show additional info.
+                """
                 assert True is True
 
     def describe_second_level_again():

--- a/test/test_formats/test_functions.py
+++ b/test/test_formats/test_functions.py
@@ -28,5 +28,14 @@ def test_with_custom_description():
     assert some_function(None) is None
 
 
+def test_with_multiline_docstring():
+    """
+    Shows custom message from docstring summary
+
+    And doesn't show additional info.
+    """
+    assert some_function(None) is None
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_formats/test_methods.py
+++ b/test/test_formats/test_methods.py
@@ -25,6 +25,14 @@ class TestFormats(unittest.TestCase):
         """Shows custom message from docstring summary"""
         assert SomeClass().some_method(None) is None
 
+    def test_with_multiline_docstring(self):
+        """
+        Shows custom message from docstring summary
+
+        And doesn't show additional info.
+        """
+        assert SomeClass().some_method(None) is None
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
In many styleguides multiline docstrings should look like:
```python
"""
First line with title.

Long and boring text with additional information...
"""
```

But because `docstring_summary` splits docstring by newlines and catches only the first line it will be empty in such cases.

So I added tests for that scenario and workaround with `lstrip()`