### PR TITLE
Add support for custom function prefixes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,6 +22,8 @@ jobs:
         run: poetry install
       - name: Test with pytest
         run: poetry run pytest .
+      - name: Test with different python_functions
+        run: poetry run pytest -o python_functions=describe .
   test-os:
     strategy:
       fail-fast: false
@@ -41,6 +43,8 @@ jobs:
         run: poetry install
       - name: Test with pytest
         run: poetry run pytest .
+      - name: Test with different python_functions
+        run: poetry run pytest -o python_functions=describe .
   test-pytest:
     strategy:
       fail-fast: false
@@ -63,3 +67,5 @@ jobs:
         run: poetry install
       - name: Test with pytest
         run: poetry run pytest .
+      - name: Test with different python_functions
+        run: poetry run pytest -o python_functions=describe .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ six = "*"
 [tool.poetry.dev-dependencies]
 mock = ">1.0.1"
 pytest = "*"
-pytest-describe = "*"
+pytest-describe = "^1.0.0"
 pytest-flake8 = "*"
 pytest-cov = "*"
 wheel = "*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pytest-spec"
-version = "3.2.0"
+version = "3.3.0rc1"
 description = "Library pytest-spec is a pytest plugin to display test execution output like a SPECIFICATION."
 readme = "README.md"
 authors = ["Pawel Chomicki <pawel.chomicki@gmail.com>"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,3 +3,4 @@ addopts=--flake8 --spec --cov=pytest_spec --cov-report=term-missing
 flake8-max-line-length=150
 spec_test_format={result} {docstring_summary}
 spec_ignore=FLAKE8
+console_output_style=classic

--- a/test/test_formats/test_functions.py
+++ b/test/test_formats/test_functions.py
@@ -37,5 +37,9 @@ def test_with_multiline_docstring():
     assert some_function(None) is None
 
 
+def describe_test_different_python_functions_name():
+    assert some_function(None) is None
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Related to #45

@satyanash @bukzor are you able to check this change before release?

Implementation is limited only to function prefixes (globs are not supported). I run following command to check results:

```
pytest -o python_functions=describe .
```

Classes are not supported because based on my tests pytest will execute every class which has tests.