### PR TITLE
Add support for Python 3.10

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10"]
+        python-version: ["3.9"]
         poetry-version: [1.1.13]
         os: [ubuntu-18.04]
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.10]
+        python-version: ["3.10"]
         poetry-version: [1.1.13]
         os: [ubuntu-18.04]
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,8 +9,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.9]
-        poetry-version: [1.0.10]
+        python-version: [3.10]
+        poetry-version: [1.1.13]
         os: [ubuntu-18.04]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: "3.10"
+          python-version: "3.9"
       - name: Run image
         uses: abatilo/actions-poetry@v2.0.0
         with:
@@ -45,13 +45,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        pytest-version: [3.9.3, 4.6.11, 5.4.3, 6.1.2]
+        pytest-version: [3.9.3, 4.6.11, 5.4.3, 6.2.5, 7.0.1]
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: "3.10"
+          python-version: "3.9"
       - uses: BSFishy/pip-action@v1
         with:
           packages: pytest==${{ matrix.pytest-version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [2.7, 3.5, 3.6, 3.7, 3.8, 3.9]
+        python-version: [2.7, 3.5, 3.6, 3.7, 3.8, 3.9, 3.10]
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2
@@ -17,7 +17,7 @@ jobs:
       - name: Run image
         uses: abatilo/actions-poetry@v2.0.0
         with:
-          poetry-version: 1.0.10
+          poetry-version: 1.1.13
       - name: Install projects
         run: poetry install
       - name: Test with pytest
@@ -32,11 +32,11 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: 3.9
+          python-version: 3.10
       - name: Run image
         uses: abatilo/actions-poetry@v2.0.0
         with:
-          poetry-version: 1.0.10
+          poetry-version: 1.1.13
       - name: Install projects
         run: poetry install
       - name: Test with pytest
@@ -51,14 +51,14 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: 3.9
+          python-version: 3.10
       - uses: BSFishy/pip-action@v1
         with:
           packages: pytest==${{ matrix.pytest-version }}
       - name: Run image
         uses: abatilo/actions-poetry@v2.0.0
         with:
-          poetry-version: 1.0.10
+          poetry-version: 1.1.13
       - name: Install projects
         run: poetry install
       - name: Test with pytest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [2.7, 3.5, 3.6, 3.7, 3.8, 3.9, 3.10]
+        python-version: ["2.7", "3.5", "3.6", "3.7", "3.8", "3.9", "3.10"]
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: 3.10
+          python-version: "3.10"
       - name: Run image
         uses: abatilo/actions-poetry@v2.0.0
         with:
@@ -51,7 +51,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: 3.10
+          python-version: "3.10"
       - uses: BSFishy/pip-action@v1
         with:
           packages: pytest==${{ matrix.pytest-version }}

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,6 @@
+v.3.3.0
+- Added support for Python 3.10
+
 v.3.2.0
 - Added support for multiline docstrings
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
         <img src="https://badgen.net/badge/python/3.7/green">
         <img src="https://badgen.net/badge/python/3.8/green">
         <img src="https://badgen.net/badge/python/3.9/green">
+        <img src="https://badgen.net/badge/python/3.10/green">
     </p>
     <p align="center">
         <img src="https://badgen.net/badge/os/linux/blue">
@@ -52,7 +53,7 @@ You can configure the format of the test headers by specifying a [format string]
     ; since pytest 4.6.x
     [pytest]
     spec_header_format = {module_path}:
-    
+
     ; legacy pytest
     [tool:pytest]
     spec_header_format = {module_path}:
@@ -73,7 +74,7 @@ You can configure the format of the test results by specifying a [format string]
     ; since pytest 4.6.x
     [pytest]
     spec_test_format = {result} {name}
-    
+
     ; legacy pytest
     [tool:pytest]
     spec_test_format = {result} {name}
@@ -85,7 +86,7 @@ or
     ; since pytest 4.6.x
     [pytest]
     spec_test_format = {result} {docstring_summary}
-    
+
     ; legacy pytest
     [tool:pytest]
     spec_test_format = {result} {docstring_summary}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pytest-spec"
-version = "3.2.0"
+version = "3.3.0"
 description = "Library pytest-spec is a pytest plugin to display test execution output like a SPECIFICATION."
 readme = "README.md"
 authors = ["Pawel Chomicki <pawel.chomicki@gmail.com>"]
@@ -19,6 +19,7 @@ classifiers = [
     "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
     "Topic :: Software Development :: Libraries",
     "Topic :: Software Development :: Testing",
     "Topic :: Utilities"


### PR DESCRIPTION
Changes to add support for Python 3.10. New releases should based on Python 3.10. Related to #47 