### PR TITLE
Also support stdlib mock

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ include = ["LICENSE.txt"]
 six = "*"
 
 [tool.poetry.dev-dependencies]
-mock = ">1.0.1"
+mock = { version = ">1.0.1", python = "~2.7" }
 pytest = "*"
 pytest-describe = "*"
 pytest-flake8 = "*"

--- a/test/test_patch.py
+++ b/test/test_patch.py
@@ -4,7 +4,10 @@
 """
 import unittest
 
-from mock import Mock, call
+try:
+    from unittest.mock import Mock, call
+except ImportError:
+    from mock import Mock, call
 
 import pytest_spec
 from pytest_spec.patch import pytest_runtest_logstart, pytest_runtest_logreport

--- a/test/test_plugin.py
+++ b/test/test_plugin.py
@@ -4,7 +4,10 @@
 """
 import unittest
 
-from mock import Mock, call, patch
+try:
+    from unittest.mock import Mock, call, patch
+except ImportError:
+    from mock import Mock, call, patch
 from pytest_spec.plugin import pytest_addoption, pytest_configure
 
 

--- a/test/test_replacer.py
+++ b/test/test_replacer.py
@@ -4,7 +4,10 @@
 """
 import unittest
 
-from mock import patch
+try:
+    from unittest.mock import patch
+except ImportError:
+    from mock import patch
 from pytest_spec.replacer import logstart_replacer, report_replacer
 
 


### PR DESCRIPTION
Python >=3.3 has included mock in the standard library, so try and
import that before falling back to the external mock.