### PR TITLE
Drop support for EOL Python 2.7

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,15 +11,15 @@ jobs:
       matrix:
         python-version: [3.9]
         poetry-version: [1.0.10]
-        os: [ubuntu-18.04]
+        os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v3
         with:
           python-version: ${{ matrix.python-version }}
       - name: Run image
-        uses: abatilo/actions-poetry@v2.0.0
+        uses: abatilo/actions-poetry@v2.1.4
         with:
           poetry-version: ${{ matrix.poetry-version }}
       - name: Install projects

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,6 @@
 name: test
 
-on: [push]
+on: [push, pull_request, workflow_dispatch]
 
 jobs:
   test-python:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,14 +8,14 @@ jobs:
       fail-fast: false
       matrix:
         python-version: [3.5, 3.6, 3.7, 3.8, 3.9]
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v3
         with:
           python-version: ${{ matrix.python-version }}
       - name: Run image
-        uses: abatilo/actions-poetry@v2.0.0
+        uses: abatilo/actions-poetry@v2.1.4
         with:
           poetry-version: 1.0.10
       - name: Install projects
@@ -26,15 +26,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-18.04, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v3
         with:
           python-version: 3.9
       - name: Run image
-        uses: abatilo/actions-poetry@v2.0.0
+        uses: abatilo/actions-poetry@v2.1.4
         with:
           poetry-version: 1.0.10
       - name: Install projects
@@ -46,17 +46,17 @@ jobs:
       fail-fast: false
       matrix:
         pytest-version: [3.9.3, 4.6.11, 5.4.3, 6.1.2]
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v3
         with:
           python-version: 3.9
       - uses: BSFishy/pip-action@v1
         with:
           packages: pytest==${{ matrix.pytest-version }}
       - name: Run image
-        uses: abatilo/actions-poetry@v2.0.0
+        uses: abatilo/actions-poetry@v2.1.4
         with:
           poetry-version: 1.0.10
       - name: Install projects

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [2.7, 3.5, 3.6, 3.7, 3.8, 3.9]
+        python-version: [3.5, 3.6, 3.7, 3.8, 3.9]
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 <p>
     <h1 align="center">pytest-spec</h1>
     <p align="center">
-        <img src="https://badgen.net/badge/python/2.7/green">
         <img src="https://badgen.net/badge/python/3.5/green">
         <img src="https://badgen.net/badge/python/3.6/green">
         <img src="https://badgen.net/badge/python/3.7/green">

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,6 @@ python = ">=3.5"
 six = "*"
 
 [tool.poetry.dev-dependencies]
-mock = ">1.0.1"
 pytest = "*"
 pytest-describe = "*"
 pytest-flake8 = "*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,6 @@ include = ["LICENSE.txt"]
 
 [tool.poetry.dependencies]
 python = ">=3.5"
-six = "*"
 
 [tool.poetry.dev-dependencies]
 pytest = "*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,8 +12,8 @@ classifiers = [
     "Operating System :: MacOS :: MacOS X",
     "Operating System :: Microsoft :: Windows",
     "Operating System :: POSIX",
-    "Programming Language :: Python :: 2.7",
     "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
     "Programming Language :: Python :: 3.5",
     "Programming Language :: Python :: 3.6",
     "Programming Language :: Python :: 3.7",
@@ -30,6 +30,7 @@ packages = [
 include = ["LICENSE.txt"]
 
 [tool.poetry.dependencies]
+python = ">=3.5"
 six = "*"
 
 [tool.poetry.dev-dependencies]

--- a/pytest_spec/__init__.py
+++ b/pytest_spec/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 :author: Pawel Chomicki
 """

--- a/pytest_spec/patch.py
+++ b/pytest_spec/patch.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Module contains method that will be replaced by the plugin.
 
 :author: Pawel Chomicki
@@ -183,7 +182,7 @@ def _get_test_name(nodeid):
         test_name_parts = test_name.split('  ')
         if len(test_name_parts) == 1:
             return test_name.strip().capitalize()
-        return 'The ({0}) {1}'.format(test_name_parts[0][1:].replace(' ', '_'), test_name_parts[1])
+        return 'The ({}) {}'.format(test_name_parts[0][1:].replace(' ', '_'), test_name_parts[1])
     return test_name
 
 

--- a/pytest_spec/plugin.py
+++ b/pytest_spec/plugin.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Module contains command line option definition and logic needed to enable new formatting.
 
 :author: Pawel Chomicki

--- a/pytest_spec/plugin.py
+++ b/pytest_spec/plugin.py
@@ -56,12 +56,12 @@ def pytest_addoption(parser):
 
 def pytest_configure(config):
     if getattr(config.option, 'spec', 0) and not getattr(config.option, 'quiet', 0) and not getattr(config.option, 'verbose', 0):
-        import six
+        import importlib
         import _pytest
         _pytest.terminal.TerminalReporter.pytest_runtest_logstart = logstart_replacer
         _pytest.terminal.TerminalReporter.pytest_runtest_logreport = report_replacer
         _pytest.terminal.TerminalReporter.pytest_collection_modifyitems = modifyitems_replacer
-        six.moves.reload_module(_pytest)
+        importlib.reload(_pytest)
 
 
 @pytest.mark.hookwrapper

--- a/pytest_spec/replacer.py
+++ b/pytest_spec/replacer.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Module contains method for replace operation.
 
 Additional method are necessary because self is not yet defined and module

--- a/test/test_formats/test_describe_format.py
+++ b/test/test_formats/test_describe_format.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 :author: Pawel Chomicki
 :e-mail: pawel.chomicki@gmail.com

--- a/test/test_formats/test_functions.py
+++ b/test/test_formats/test_functions.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 :author: Pawel Chomicki
 :e-mail: pawel.chomicki@gmail.com

--- a/test/test_formats/test_methods.py
+++ b/test/test_formats/test_methods.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 :author: Pawel Chomicki
 :e-mail: pawel.chomicki@gmail.com
@@ -6,7 +5,7 @@
 import unittest
 
 
-class SomeClass(object):
+class SomeClass:
     def some_method(self, arg):
         return arg
 

--- a/test/test_patch.py
+++ b/test/test_patch.py
@@ -1,16 +1,15 @@
-# -*- coding: utf-8 -*-
 """
 :author: Pawel Chomicki
 """
 import unittest
 
-from mock import Mock, call
+from unittest.mock import Mock, call
 
 import pytest_spec
 from pytest_spec.patch import pytest_runtest_logstart, pytest_runtest_logreport
 
 
-class FakeHook(object):
+class FakeHook:
     def __init__(self, *args, **kwargs):
         self.cat = kwargs.get('cat', ' ')
         self.letter = kwargs.get('letter', ' ')
@@ -20,7 +19,7 @@ class FakeHook(object):
         return self.cat, self.letter, self.word
 
 
-class FakeConfig(object):
+class FakeConfig:
 
     def __init__(self, *args, **kwargs):
         self.hook = FakeHook(*args, **kwargs)
@@ -43,12 +42,12 @@ class FakeConfig(object):
         return result
 
 
-class FakeStats(object):
+class FakeStats:
     def setdefault(self, first, second):
         return []
 
 
-class FakeSelf(object):
+class FakeSelf:
     def __init__(self, *args, **kwargs):
         self.config = FakeConfig(*args, **kwargs)
         self.currentfspath = None
@@ -56,7 +55,7 @@ class FakeSelf(object):
         self.stats = FakeStats()
 
 
-class FakeReport(object):
+class FakeReport:
     def __init__(self, nodeid, *args, **kwargs):
         self.nodeid = nodeid
         self.passed = kwargs.get('passed', True)

--- a/test/test_plugin.py
+++ b/test/test_plugin.py
@@ -33,12 +33,12 @@ class TestPlugin(unittest.TestCase):
                                                               dest='spec',
                                                               help='Print test result in specification format')])
 
-    @patch('six.moves.reload_module')
+    @patch('importlib.reload')
     def test__pytest_configure__should_not_reload_configuration(self, imp_mock):
         pytest_configure(FakeConfig(spec=False))
         self.assertEqual(len(imp_mock.mock_calls), 0)
 
-    @patch('six.moves.reload_module')
+    @patch('importlib.reload')
     def test__pytest_configure__reloads_pytest_after_patching(self, imp_mock):
         pytest_configure(FakeConfig(spec=True))
         self.assertEqual(len(imp_mock.mock_calls), 1)

--- a/test/test_plugin.py
+++ b/test/test_plugin.py
@@ -1,20 +1,19 @@
-# -*- coding: utf-8 -*-
 """
 :author: Pawel Chomicki
 """
 import unittest
 
-from mock import Mock, call, patch
+from unittest.mock import Mock, call, patch
 from pytest_spec.plugin import pytest_addoption, pytest_configure
 
 
-class FakeOption(object):
+class FakeOption:
     def __init__(self, spec=False):
         self.spec = spec
         self.verbose = 0
 
 
-class FakeConfig(object):
+class FakeConfig:
     def __init__(self, spec):
         self.option = FakeOption(spec=spec)
 

--- a/test/test_replacer.py
+++ b/test/test_replacer.py
@@ -1,10 +1,9 @@
-# -*- coding: utf-8 -*-
 """
 :author: Pawel Chomicki
 """
 import unittest
 
-from mock import patch
+from unittest.mock import patch
 from pytest_spec.replacer import logstart_replacer, report_replacer
 
 

--- a/test/test_results/test_as_class.py
+++ b/test/test_results/test_as_class.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 :author: Pawel Chomicki
 :e-mail: pawel.chomicki@gmail.com

--- a/test/test_results/test_as_functions.py
+++ b/test/test_results/test_as_functions.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 :author: Pawel Chomicki
 :e-mail: pawel.chomicki@gmail.com


### PR DESCRIPTION
Fixes https://github.com/pchomik/pytest-spec/issues/49.

---

Python 3.5 is failing on the CI. I recommend dropping it too, it's been EOL end-of-life since 2020-09-13 and also pytest itself no longer supports it.

I'd also drop 3.6 too, also EOL and unsupported by pytest.

This would allow modernising the syntax further and make maintenance easier.


| cycle | latest |    eol     | latestReleaseDate | releaseDate |
|:------|:-------|:----------:|:-----------------:|:-----------:|
| 3.10  | 3.10.4 | 2026-10-04 |     2022-03-23    |  2021-10-04 |
| 3.9   | 3.9.13 | 2025-10-05 |     2022-05-17    |  2020-10-05 |
| 3.8   | 3.8.13 | 2024-10-14 |     2022-03-16    |  2019-10-14 |
| 3.7   | 3.7.13 | 2023-06-27 |     2022-03-16    |  2018-06-26 |
| 3.6   | 3.6.15 | 2021-12-23 |     2021-09-03    |  2016-12-22 |
| 3.5   | 3.5.10 | 2020-09-13 |     2020-09-05    |  2015-09-12 |
| 2.7   | 2.7.18 | 2020-01-01 |     2020-04-19    |  2010-07-03 |

https://endoflife.date/python
