### PR TITLE
Updating patch.py to handle cases where the test has a '.' in the name

### DIFF
--- a/pytest_spec/patch.py
+++ b/pytest_spec/patch.py
@@ -81,7 +81,7 @@ def pytest_runtest_logreport(self, report):
     if not isinstance(word, tuple):
         test_name = _get_test_name(report.nodeid)
         docstring_summary = getattr(report, 'docstring_summary', '')
-        docstring_summary = docstring_summary if docstring_summary else test_name
+        docstring_summary = docstring_summary if docstring_summary else ""
         markup, test_status = _format_results(report, self.config)
         depth = len(self.current_scopes) or 1
         _print_test_result(self, test_name, docstring_summary, test_status, markup, depth)
@@ -150,6 +150,8 @@ def _remove_test_container_prefix(nodeid):
 
 
 def _remove_file_extension(nodeid):
+    if ".py" not in nodeid:
+        return nodeid
     return os.path.splitext(nodeid)[0]
 
 


### PR DESCRIPTION
So, i'm using [pytest-describe](https://github.com/pytest-dev/pytest-describe) and pytest-spec

When i was trying these tests:

```python
import pytest
from utils.semantic_version_calculator import (
    bump_semantic_version,
    is_semantic_version_bigger,
)


def describe_is_semantic_version_bigger() -> None:
    @pytest.mark.parametrize(
        ("v1", "v2"),
        [
            ("1.0.0", "0.9.9"),
            ("2.1.3", "2.1.2"),
        ],
    )
    def should_check_version_is_bigger(v1: str, v2: str) -> None:
        assert is_semantic_version_bigger(v1, v2) is True

    @pytest.mark.parametrize(
        ("v1", "v2"),
        [
            ("3.2.1", "3.2.1"),
            ("0.1.0", "0.2.0"),
        ],
    )
    def should_check_version_is_not_bigger(v1: str, v2: str) -> None:
        assert is_semantic_version_bigger(v1, v2) is False
```

and with this `pyproject.toml` config:

```toml
[tool.pytest.ini_options]
addopts = "--spec"
spec_header_format = "📘 {module_path}:"
spec_test_format = "{result} {name}{docstring_summary}"
```

i would get the following output:

```log
❯ just test
pytest -s --durations=5 tests/unit
=================================== test session starts ====================================
platform linux -- Python 3.12.4, pytest-8.3.2, pluggy-1.5.0
rootdir: /home/guilherme/dex/dbt_project
configfile: pyproject.toml
plugins: spec-4.0.0, describe-2.2.0, cov-5.0.0
collected 8 items

📘 tests/unit/test_semantic_version_calculator.py:

Bump semantic version:
  ✓ Should bump a version by one[1.0.0-1.0Should bump a version by one[1.0.0-1.0
  ✓ Should bump a version by one[2.1.3-2.1Should bump a version by one[2.1.3-2.1
  ✓ Should bump a version by one[3.2.1-3.2Should bump a version by one[3.2.1-3.2
  ✓ Should bump a version by one[0.1.0-0.1Should bump a version by one[0.1.0-0.1

Is semantic version bigger:
  ✓ Should check version is bigger[1.0.0-0.9Should check version is bigger[1.0.0-0.9
  ✓ Should check version is bigger[2.1.3-2.1Should check version is bigger[2.1.3-2.1
  ✓ Should check version is not bigger[3.2.1-3.2Should check version is not bigger[3.2.1-3.2
  ✓ Should check version is not bigger[0.1.0-0.2Should check version is not bigger[0.1.0-0.2

=================================== slowest 5 durations ====================================

(5 durations < 0.005s hidden.  Use -vv to show these durations.)
==================================== 8 passed in 0.03s =====================================
```

which is odd...

thus, with this ~fix, i get the following output:

```log
❯ just test
pytest -s --durations=5 tests/unit
=================================== test session starts ====================================
platform linux -- Python 3.12.4, pytest-8.3.2, pluggy-1.5.0
rootdir: /home/guilherme/dex/dbt_project
configfile: pyproject.toml
plugins: spec-4.0.0, describe-2.2.0, cov-5.0.0
collected 8 items

📘 tests/unit/test_semantic_version_calculator.py:

Bump semantic version:
  ✓ Should bump a version by one[1.0.0-1.0.1]
  ✓ Should bump a version by one[2.1.3-2.1.4]
  ✓ Should bump a version by one[3.2.1-3.2.2]
  ✓ Should bump a version by one[0.1.0-0.1.1]

Is semantic version bigger:
  ✓ Should check version is bigger[1.0.0-0.9.9]
  ✓ Should check version is bigger[2.1.3-2.1.2]
  ✓ Should check version is not bigger[3.2.1-3.2.1]
  ✓ Should check version is not bigger[0.1.0-0.2.0]

=================================== slowest 5 durations ====================================

(5 durations < 0.005s hidden.  Use -vv to show these durations.)
==================================== 8 passed in 0.03s =====================================
```

