### PR TITLE
Improve class name and parameter strings

### DIFF
--- a/pytest_spec/patch.py
+++ b/pytest_spec/patch.py
@@ -12,6 +12,16 @@ from _pytest.main import Session
 from _pytest.nodes import Item
 from _pytest.reports import TestReport
 
+BOUNDARIES_REGEXP = re.compile(
+    r"""
+        (?<=[A-Z])(?=[A-Z][a-z]) # Split between acronyms and words, e.g. "PDFFile" -> "PDF File"
+        |(?<=[a-z])(?=[A-Z])     # Split between words
+        |(?<=[A-Za-z])(?=[0-9])  # Split between letters and numbers
+        |(?<=[0-9])(?=[A-Za-z])  # Split between numbers and letters
+    """,
+    re.VERBOSE,
+)
+
 
 def pytest_runtest_logstart(self, nodeid: str, location: Tuple[str, int, str]) -> None:
     """Signal the start of running a single test item.
@@ -112,13 +122,7 @@ def prettify(string: str) -> str:
 
 
 def _split_boundaries(string: str) -> str:
-    boundaries = re.compile(r"""
-        (?<=[A-Z])(?=[A-Z][a-z]) # Split between acronyms and words, e.g. "PDFFile" -> "PDF File"
-        |(?<=[a-z])(?=[A-Z])     # Split between words
-        |(?<=[A-Za-z])(?=[0-9])  # Split between letters and numbers
-        |(?<=[0-9])(?=[A-Za-z])  # Split between numbers and letters
-    """, re.VERBOSE)
-    return boundaries.sub(" ", string)
+    return BOUNDARIES_REGEXP.sub(" ", string)
 
 
 def prettify_test(string: str) -> str:

--- a/pytest_spec/patch.py
+++ b/pytest_spec/patch.py
@@ -108,11 +108,17 @@ def _is_nodeid_has_test(nodeid: str) -> bool:
 
 
 def prettify(string: str) -> str:
-    return _capitalize_first_letter(_split_words(_replace_underscores(_remove_test_container_prefix(_remove_file_extension(string)))))
+    return _capitalize_first_letter(_split_boundaries(_replace_underscores(_remove_test_container_prefix(_remove_file_extension(string)))))
 
 
-def _split_words(string: str):
-    return re.sub(r"(\w)([A-Z])", r"\1 \2", string).strip()
+def _split_boundaries(string: str) -> str:
+    boundaries = re.compile(r"""
+        (?<=[A-Z])(?=[A-Z][a-z]) # Split between acronyms and words, e.g. "PDFFile" -> "PDF File"
+        |(?<=[a-z])(?=[A-Z])     # Split between words
+        |(?<=[A-Za-z])(?=[0-9])  # Split between letters and numbers
+        |(?<=[0-9])(?=[A-Za-z])  # Split between numbers and letters
+    """, re.VERBOSE)
+    return boundaries.sub(" ", string)
 
 
 def prettify_test(string: str) -> str:

--- a/test/test_patch.py
+++ b/test/test_patch.py
@@ -145,7 +145,6 @@ class TestPatch(unittest.TestCase):
             with self.subTest(test_suffix=test_suffix, expected_result=expected_result):
                 fake_self = FakeSelf()
                 pytest_runtest_logreport(fake_self, FakeReport(f"Test::Second::test_example_{test_suffix}"))
-                print(fake_self._tw.write.mock_calls)
                 fake_self._tw.write.assert_has_calls([call("Second:"), call(f"  ✓ Example {expected_result}", green=True)])
 
     def test__pytest_runtest_longreport__uses_docstring_summary(self):

--- a/test/test_patch.py
+++ b/test/test_patch.py
@@ -132,9 +132,9 @@ class TestPatch(unittest.TestCase):
         cases = [
             ("Demo_CamelCase", "Demo Camel Case"),
             ("PDFFile", "PDF File"),
-            ("camelCase", "camel Case"),
+            ("camelCase", "Camel Case"),
             ("PascalCase", "Pascal Case"),
-            ("lowerACRONYM", "lower ACRONYM"),
+            ("lowerACRONYM", "Lower ACRONYM"),
             ("Word123", "Word 123"),
             ("123Word", "123 Word"),
             ("Office365API", "Office 365 API"),
@@ -144,8 +144,8 @@ class TestPatch(unittest.TestCase):
         for test_suffix, expected_result in cases:
             with self.subTest(test_suffix=test_suffix, expected_result=expected_result):
                 fake_self = FakeSelf()
-                pytest_runtest_logreport(fake_self, FakeReport(f"Test::Second::test_example_{test_suffix}"))
-                fake_self._tw.write.assert_has_calls([call("Second:"), call(f"  ✓ Example {expected_result}", green=True)])
+                pytest_runtest_logreport(fake_self, FakeReport(f"Test::Second::test_{test_suffix}"))
+                fake_self._tw.write.assert_has_calls([call("Second:"), call(f"  ✓ {expected_result}", green=True)])
 
     def test__pytest_runtest_longreport__uses_docstring_summary(self):
         fake_self = FakeSelf()

--- a/test/test_patch.py
+++ b/test/test_patch.py
@@ -128,12 +128,25 @@ class TestPatch(unittest.TestCase):
         pytest_runtest_logreport(fake_self, FakeReport("Test::Second::test__example"))
         fake_self._tw.write.assert_has_calls([call("Second:"), call("  ✓ Example", green=True)])
 
-    def test__pytest_runtest_logreport__honors_capitalization_of_words_in_test_name(
-        self,
-    ):
-        fake_self = FakeSelf()
-        pytest_runtest_logreport(fake_self, FakeReport("Test::Second::test_example_Demo_CamelCase"))
-        fake_self._tw.write.assert_has_calls([call("Second:"), call("  ✓ Example Demo Camel Case", green=True)])
+    def test__pytest_runtest_logreport__honors_different_type_of_baundaries_between_words(self):
+        cases = [
+            ("Demo_CamelCase", "Demo Camel Case"),
+            ("PDFFile", "PDF File"),
+            ("camelCase", "camel Case"),
+            ("PascalCase", "Pascal Case"),
+            ("lowerACRONYM", "lower ACRONYM"),
+            ("Word123", "Word 123"),
+            ("123Word", "123 Word"),
+            ("Office365API", "Office 365 API"),
+            ("ACRONYM", "ACRONYM"),
+            ("ACRONYMletter", "ACRONY Mletter"),
+        ]
+        for test_suffix, expected_result in cases:
+            with self.subTest(test_suffix=test_suffix, expected_result=expected_result):
+                fake_self = FakeSelf()
+                pytest_runtest_logreport(fake_self, FakeReport(f"Test::Second::test_example_{test_suffix}"))
+                print(fake_self._tw.write.mock_calls)
+                fake_self._tw.write.assert_has_calls([call("Second:"), call(f"  ✓ Example {expected_result}", green=True)])
 
     def test__pytest_runtest_longreport__uses_docstring_summary(self):
         fake_self = FakeSelf()


### PR DESCRIPTION
In `5.1.0` a change was introduced to fix issue #46  where `WhenFooIsBar` is converted to `When Foo Is Bar`.

However this had, for me, a detrimental effect. Class names formatted like `PDFFile` become `P DF File` instead of `PDF File`.

I've changed the `pytest_spec.patch._split_words` function to do slightly more complex splitting.

```python
examples = [
    "PDFFile",
    "camelCase",
    "PascalCase",
    "lowerACRONYM",
    "Word123",
    "123Word",
    "Office365API",
    "ACRONYM",
    "ACRONYMletter"
]

for example in examples:
    print(f"{example}  : '{prettify_old(example)}' => '{prettify(example)}'")
```
Output:
```
PDFFile : 'P DF File' => 'PDF File'
camelCase : 'Camel Case' => 'Camel Case'
PascalCase : 'Pascal Case' => 'Pascal Case'
lowerACRONYM : 'Lower AC RO NY M' => 'Lower ACRONYM'
Word123 : 'Word123' => 'Word 123'
123Word : '123 Word' => '123 Word'
Office365API : 'Office365 AP I' => 'Office 365 API'
ACRONYM : 'A CR ON YM' => 'ACRONYM'
ACRONYMletter : 'A CR ON YMletter' => 'ACRONY Mletter'
```

As you can see from the last example, the only case I couldn't cover is where an acronym goes before a lower case letter but this contradicts the first example so seems appropriate to leave as is.