### PR TITLE
Update pytest hook implementation marker to use pluggy API

### DIFF
--- a/pytest_spec/plugin.py
+++ b/pytest_spec/plugin.py
@@ -75,7 +75,7 @@ def pytest_configure(config: Config) -> None:
         importlib.reload(_pytest)
 
 
-@pytest.mark.hookwrapper
+@pytest.hookimpl(hookwrapper=True)
 def pytest_runtest_makereport(item: Item, call: CallInfo) -> Any:
     """Adds docstring summary to the report."""
     outcome = yield


### PR DESCRIPTION
Declaring hook wrappers using markers is now deprecated and makes Pytest show warning messages. Use pluggy API as recommended.

See https://docs.pytest.org/en/latest/deprecations.html#configuring-hook-specs-impls-using-markers