### PR TITLE
Add spec_container_format

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,84 @@ In addition to the `{path}` and `{class_name}` replacement fields, there is also
 
 <details>
 
+<summary>spec_container_format</summary>
+
+### spec_container_format
+
+You can configure the format of the test containers by specifying a [format string](https://docs.python.org/2/library/string.html#format-string-syntax) in your [ini-file](https://docs.pytest.org/en/stable/customize.html#pytest-ini):
+
+3 variables are available:
+
+- sentence - capitalize first letter and remove all underscores
+- unit_name - leaves capitalization and underscores 
+- docstring_summary - first line from test docstring if available
+
+```ini
+    ; since pytest 4.6.x
+    [pytest]
+    spec_container_format = {sentence}
+
+    ; legacy pytest
+    [tool:pytest]
+    spec_container_format = {sentence}
+```
+
+or
+
+```ini
+    ; since pytest 4.6.x
+    [pytest]
+    spec_container_format = {docstring_summary}
+
+    ; legacy pytest
+    [tool:pytest]
+    spec_container_format = {docstring_summary}
+```
+
+In second example where docstring is not available the container name will be formatted as a sentence.
+
+Similar configuration could be done in your [pyproject.toml](https://docs.pytest.org/en/stable/reference/customize.html#pyproject-toml) file:
+
+```toml
+    [tool.pytest.ini_options]
+    spec_container_format = "{sentence}"
+```
+
+or
+
+```toml
+    [tool.pytest.ini_options]
+    spec_container_format = "{docstring_summary}"
+```
+
+Here are some examples of what each format looks like:
+```python
+'''
+Outputs:
+    {sentence}         -> Fibonacci sequence:
+    {unit_name}        -> FibonacciSequence:
+    {docstring_sumary} -> fibonacci_sequence():
+'''
+class TestFibonacciSequence:
+    """fibonacci_sequence()"""
+    ...
+
+
+'''
+Outputs:
+    {sentence}          -> Fibonacci sequence:
+    {unit_name}         -> fibonacci_sequence:
+    {docstring_summary} -> fibonacci_sequence():
+'''
+def describe_fibonacci_sequence():
+    """fibonacci_sequence()"""
+    ...
+```
+
+</details>
+
+<details>
+
 <summary>spec_test_format</summary>
 
 ### spec_test_format

--- a/pytest_spec/patch.py
+++ b/pytest_spec/patch.py
@@ -5,7 +5,7 @@
 
 import os
 import re
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple, Generator, Callable
 
 from _pytest.config import Config
 from _pytest.main import Session
@@ -22,6 +22,24 @@ BOUNDARIES_REGEXP = re.compile(
     re.VERBOSE,
 )
 
+def iterate_nodeid_hierarchy(previous: list[str], current: list[str]) -> Generator[str, None, None]:
+    common_index = 0
+    for prev, curr in zip(previous, current):
+        if prev == curr:
+            common_index += 1
+        else:
+            break
+    yield from current[common_index:]
+
+def iterate_describe_hierarchy(previous: list[Callable[..., None]], current: list[Callable[..., None]]) -> Generator[Callable[..., None], None, None]:
+    common_index = 0
+    for prev, curr in zip(reversed(previous), reversed(current)):
+        if prev == curr:
+            common_index += 1
+        else:
+            break
+    end_index = len(current) - common_index
+    yield from reversed(current[:end_index])
 
 def pytest_runtest_logstart(self, nodeid: str, location: Tuple[str, int, str]) -> None:
     """Signal the start of running a single test item.
@@ -84,24 +102,19 @@ def pytest_runtest_logreport(self, report: TestReport) -> None:
     if test_path != self.currentfspath:
         self.currentfspath = test_path
         _print_description(self)
+    
+    if report.describe_hierarchy:
+        containers = iterate_describe_hierarchy(self.previous_describes, report.describe_hierarchy)
+    else:
+        containers = iterate_nodeid_hierarchy(self.previous_scopes, self.current_scopes)
 
     scope_ind = 0
-    if report.describe_hierarchy:
-        for describe in reversed(report.describe_hierarchy):
-            if describe not in self.previous_describes:
-                msg = [indent * scope_ind + _format_container_description(describe, self.config)]
-                msg = "\n".join(msg)
-                if msg.strip():
-                    _print_description(self, msg)
-            scope_ind += 1
-    else:
-        for msg in self.current_scopes:
-            if msg not in self.previous_scopes:
-                msg = [indent * scope_ind + _format_container_description(msg, self.config)]
-                msg = "\n".join(msg)
-                if msg:
-                    _print_description(self, msg)
-            scope_ind += 1
+    for container in containers:
+        msg = [indent * scope_ind + _format_container_description(container, self.config)]
+        msg = "\n".join(msg)
+        if msg.strip():
+            _print_description(self, msg)
+        scope_ind += 1
 
     self.previous_scopes = self.current_scopes
     self.previous_describes = report.describe_hierarchy

--- a/pytest_spec/patch.py
+++ b/pytest_spec/patch.py
@@ -68,6 +68,7 @@ def pytest_runtest_logreport(self, report: TestReport) -> None:
     """
     self.previous_scopes = getattr(self, "previous_scopes", [])
     self.current_scopes = get_report_scopes(report)
+    self.previous_describes = getattr(self, "previous_describes", [])
     indent = self.config.getini("spec_indent")
 
     res = self.config.hook.pytest_report_teststatus(report=report, config=self.config)
@@ -85,14 +86,25 @@ def pytest_runtest_logreport(self, report: TestReport) -> None:
         _print_description(self)
 
     scope_ind = 0
-    for msg in self.current_scopes:
-        if msg not in self.previous_scopes:
-            msg = [indent * scope_ind + prettify_description(msg)]
-            msg = "\n".join(msg)
-            if msg:
-                _print_description(self, msg)
-        scope_ind += 1
+    if report.describe_hierarchy:
+        for describe in reversed(report.describe_hierarchy):
+            if describe not in self.previous_describes:
+                msg = [indent * scope_ind + _format_container_description(describe, self.config)]
+                msg = "\n".join(msg)
+                if msg.strip():
+                    _print_description(self, msg)
+            scope_ind += 1
+    else:
+        for msg in self.current_scopes:
+            if msg not in self.previous_scopes:
+                msg = [indent * scope_ind + _format_container_description(msg, self.config)]
+                msg = "\n".join(msg)
+                if msg:
+                    _print_description(self, msg)
+            scope_ind += 1
+
     self.previous_scopes = self.current_scopes
+    self.previous_describes = report.describe_hierarchy
 
     if not isinstance(word, tuple):
         test_name = _get_test_name(report.nodeid)
@@ -132,6 +144,8 @@ def prettify_test(string: str) -> str:
 def prettify_description(string: str) -> str:
     return prettify(_append_colon(_remove_test_container_prefix(string)))
 
+def prettify_unit_name(string: str) -> str:
+    return _append_colon(_remove_test_container_prefix(string))
 
 def _get_test_path(nodeid: str, header: str) -> str:
     levels = nodeid.split("::")
@@ -166,7 +180,7 @@ def _print_description(self, msg: Optional[str] = None) -> None:
 
 
 def _remove_test_container_prefix(nodeid: str) -> str:
-    return re.sub("^(Test)|(describe)", "", nodeid)
+    return re.sub("^(Test)|(describe_?)", "", nodeid)
 
 
 def _remove_file_extension(nodeid: str) -> str:
@@ -198,6 +212,27 @@ def _append_colon(string: str) -> str:
 def _get_parametrized_parameters(test_name: str) -> str:
     m = re.search(r"\[.*\]", test_name)
     return m.group(0) if m else ""
+
+def _format_container_description(describe: Any, config: Any) -> str:
+    if type(describe) == str:
+        sentence = prettify_description(describe)
+        unit_name = prettify_unit_name(describe)
+        docstring_summary = sentence
+    else:
+        sentence = prettify_description(getattr(describe, "__name__", ""))
+        unit_name = prettify_unit_name(getattr(describe, "__name__", ""))
+        docstring_summary = getattr(describe, "__doc__", None)
+        docstring_summary = (
+            _append_colon(str(docstring_summary).lstrip().split("\n")[0])
+            if docstring_summary
+            else sentence
+        )
+
+    return config.getini("spec_container_format").format(
+        sentence=sentence,
+        unit_name=unit_name,
+        docstring_summary=docstring_summary,
+    )
 
 
 def _get_test_name(nodeid: str) -> str:

--- a/pytest_spec/plugin.py
+++ b/pytest_spec/plugin.py
@@ -31,6 +31,11 @@ def pytest_addoption(parser: Parser) -> None:
         help="The format of the test headers when using the spec plugin",
     )
     parser.addini(
+        "spec_container_format",
+        default="{sentence}:",
+        help="The format of the container descriptions when using the spec plugin",
+    )
+    parser.addini(
         "spec_test_format",
         default="{result} {name}",
         help="The format of the test results when using the spec plugin",
@@ -84,3 +89,9 @@ def pytest_runtest_makereport(item: Item, call: CallInfo) -> Any:
         report.docstring_summary = str(item.obj.__doc__).lstrip().split("\n")  # type: ignore
     else:
         report.docstring_summary = []
+
+    report.describe_hierarchy = (
+        item.get_describe_function_heirarchy()
+        if hasattr(item, "get_describe_function_heirarchy")
+        else []
+    )

--- a/test/test_patch.py
+++ b/test/test_patch.py
@@ -2,8 +2,9 @@
 :author: Pawel Chomicki
 """
 
+import pytest
 import unittest
-from unittest.mock import Mock, call
+from unittest.mock import Mock, call, ANY
 
 import pytest_spec
 from pytest_spec.patch import pytest_runtest_logreport, pytest_runtest_logstart
@@ -24,6 +25,7 @@ class FakeConfig:
         self.hook = FakeHook(*args, **kwargs)
         self.mapping = {
             "spec_header_format": "{module_path}:",
+            "spec_container_format": "{sentence}",
             "spec_test_format": "{result} {name}",
             "spec_success_indicator": "✓",
             "spec_failure_indicator": "✗",
@@ -59,7 +61,35 @@ class FakeReport:
         self.failed = kwargs.get("failed", False)
         self.skipped = kwargs.get("skipped", False)
         self.docstring_summary = ["Test documentation"]
+        self.describe_hierarchy = kwargs.get("describe_hierarchy", [])
 
+def fake_container_hierarchy(depth, withDocsring=False):
+    if 0 >= depth or depth > 2:
+        raise ValueError("Depth should be either 1 or 2")
+    
+    def describe_my_function(): pass
+    def describe_my_other_function(): pass
+    
+    def describe_my_function_with_docstring():
+        """
+        my function docstring
+        This is text that should be ignored.
+        """
+        pass
+
+    def describe_my_other_function_with_docstring():
+        """
+        my other function docstring
+        This is text that should be ignored.
+        """
+        pass
+
+    f1 = describe_my_function_with_docstring if withDocsring else describe_my_function
+    f2 = describe_my_other_function_with_docstring if withDocsring else describe_my_other_function
+    containers = f1.__name__ + "::" + f2.__name__ if depth == 2 else f1.__name__
+    nodeid = f"Test::{containers}::test_example_demo"
+    describe_heirarchy = [f1] if depth == 1 else [f2, f1]
+    return nodeid, describe_heirarchy
 
 class TestPatch(unittest.TestCase):
     def tearDown(self):
@@ -81,13 +111,6 @@ class TestPatch(unittest.TestCase):
     ):
         result = pytest_runtest_logreport(FakeSelf(), FakeReport(""))
         self.assertIsNone(result)
-
-    def test__pytest_runtest_logreport__prints_class_name_before_first_test_result(
-        self,
-    ):
-        fake_self = FakeSelf()
-        pytest_runtest_logreport(fake_self, FakeReport("Test::Second::Test_example_demo"))
-        fake_self._tw.write.assert_has_calls([call("Second:")])
 
     def test__pytest_runtest_logreport__prints_test_name_and_passed_status(self):
         fake_self = FakeSelf()
@@ -184,6 +207,100 @@ class TestPatch(unittest.TestCase):
         pytest_runtest_logreport(fake_self, FakeReport("Something"))
         assert not fake_self._tw.write.called
 
+@pytest.mark.parametrize("hirearchey_detection_method", ["nodeid", "functions"])
+class TestContainerHeirarchey:
+    def test__pytest_runtest_logreport__prints_container_name_before_first_test_result(
+        self,
+        hirearchey_detection_method,
+    ):
+        fake_self = FakeSelf()
+        fake_self.config.mapping["spec_test_format"] = "{name}"
+        nodeid, describe_hierarchy = fake_container_hierarchy(depth=1, withDocsring=False)
+        if hirearchey_detection_method == "nodeid": describe_hierarchy = None
+        
+        pytest_runtest_logreport(fake_self, FakeReport(nodeid=nodeid, describe_hierarchy=describe_hierarchy))
+
+        fake_self._tw.write.assert_has_calls([
+            call("My function:"),
+            call('  Example demo', green=ANY),
+        ])
+
+    def test__pytest_runtest_logreport__uses_unit_name_format_for_container_name(
+        self,
+        hirearchey_detection_method,
+    ):
+        fake_self = FakeSelf()
+        fake_self.config.mapping["spec_container_format"] = "{unit_name}"
+        nodeid, describe_hierarchy = fake_container_hierarchy(depth=1, withDocsring=False)
+        if hirearchey_detection_method == "nodeid": describe_hierarchy = None
+
+        pytest_runtest_logreport(fake_self, FakeReport(nodeid=nodeid, describe_hierarchy=describe_hierarchy))
+
+        fake_self._tw.write.assert_has_calls([call("my_function:")])
+
+    def test__pytest_runtest_logreport__uses_docstring_summary_format_for_container_name(
+        self,
+        hirearchey_detection_method,
+    ):
+        if hirearchey_detection_method == "nodeid":
+            pytest.skip("Docstring summary format is not supported when hierarchy is detected by nodeid")
+
+        fake_self = FakeSelf()
+        fake_self.config.mapping["spec_container_format"] = "{docstring_summary}"
+        nodeid, describe_hierarchy = fake_container_hierarchy(depth=1, withDocsring=True)
+
+        pytest_runtest_logreport(fake_self, FakeReport(nodeid=nodeid, describe_hierarchy=describe_hierarchy))
+
+        fake_self._tw.write.assert_has_calls([call("my function docstring:")])
+
+
+    def test__pytest_runtest_logreport__uses_sentence_format_when_docstring_summary_format_not_available(
+        self, hirearchey_detection_method,
+    ):
+        fake_self = FakeSelf()
+        fake_self.config.mapping["spec_container_format"] = "{docstring_summary}"
+        nodeid, describe_hierarchy = fake_container_hierarchy(depth=1, withDocsring=False)
+        if hirearchey_detection_method == "nodeid": describe_hierarchy = None
+
+        pytest_runtest_logreport(fake_self, FakeReport(nodeid=nodeid, describe_hierarchy=describe_hierarchy))
+
+        fake_self._tw.write.assert_has_calls([call("My function:")])
+
+    def test__pytest_runtest_logreport__adds_indentation_for_each_nested_container(
+        self,
+        hirearchey_detection_method,
+    ):
+        fake_self = FakeSelf()
+        indent = fake_self.config.mapping["spec_indent"]
+        nodeid, describe_hierarchy = fake_container_hierarchy(depth=2, withDocsring=False)
+        if hirearchey_detection_method == "nodeid": describe_hierarchy = None
+
+        pytest_runtest_logreport(fake_self, FakeReport(nodeid=nodeid, describe_hierarchy=describe_hierarchy))
+
+        fake_self._tw.write.assert_has_calls([
+            call("My function:"),
+            call(indent + 'My other function:'),
+        ])
+
+    def test__pytest_runtest_logreport__does_not_print_the_same_container_more_than_once(
+        self,
+        hirearchey_detection_method,
+    ):
+        fake_self = FakeSelf()
+        fake_self.config.mapping["spec_test_format"] = "{name}"
+        nodeid, describe_hierarchy = fake_container_hierarchy(depth=2, withDocsring=False)
+        if hirearchey_detection_method == "nodeid": describe_hierarchy = None
+
+        pytest_runtest_logreport(fake_self, FakeReport(nodeid=nodeid, describe_hierarchy=describe_hierarchy))
+        pytest_runtest_logreport(fake_self, FakeReport(nodeid=nodeid, describe_hierarchy=describe_hierarchy))
+
+        fake_self._tw.write.assert_has_calls([
+            call("Test:"),
+            call("My function:"),
+            call('  My other function:'),
+            call('    Example demo', green=ANY),
+            call('    Example demo', green=ANY),
+        ])
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/test_patch.py
+++ b/test/test_patch.py
@@ -302,5 +302,41 @@ class TestContainerHeirarchey:
             call('    Example demo', green=ANY),
         ])
 
+    def test__pytest_runtest_logreport__does_not_collapse_different_containers_with_the_same_name(
+        self,
+        hirearchey_detection_method,
+    ):
+        def create_heirarchy(top):
+            def describe_A(): pass
+            def describe_B(): pass
+            def describe_C(): pass
+            return [describe_C, describe_B, describe_A, top]
+        
+        def describe_I(): pass
+        def describe_II(): pass
+
+        fake_self = FakeSelf()
+        nodeid1 = f"Test::{describe_I.__name__}::describe_A::describe_B::describe_C::test_example_demo"
+        nodeid2 = f"Test::{describe_II.__name__}::describe_A::describe_B::describe_C::test_example_demo"
+        hierarchy1 = create_heirarchy(describe_I) if hirearchey_detection_method == "functions" else None
+        hierarchy2 = create_heirarchy(describe_II) if hirearchey_detection_method == "functions" else None
+
+        pytest_runtest_logreport(fake_self, FakeReport(nodeid=nodeid1, describe_hierarchy=hierarchy1))
+        pytest_runtest_logreport(fake_self, FakeReport(nodeid=nodeid2, describe_hierarchy=hierarchy2))
+
+        fake_self._tw.write.assert_has_calls([
+            call("I:"),
+            call('  A:'),
+            call('    B:'),
+            call('      C:'),
+        ])
+
+        fake_self._tw.write.assert_has_calls([
+            call("II:"),
+            call('  A:'),
+            call('    B:'),
+            call('      C:'),
+        ])
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## What's changing
This change adds support for a new formatting string called `spec_container_format`. This format string provides three variables:
- `sentence` - displays the describe/class name as a sentence with first letter capitalized and underscores removed
- `unit_name` - mostly leaves the describe/class name untouched except to remove `describe_` or `Test` from the front
- `docstring_summary` - displays the first line of the docstring if one exists, uses `sentence` formatting as fallback if a docstring is not available

## Required integration
I submitted a PR to [pytest-describe](https://github.com/pytest-dev/pytest-describe/pull/53) to expose a new API that allows the describe functions to be obtained by reporting plugins. Without this enhancement the `docstring_summary` formatting option will always fallback to `sentence` formatting.

## Example
<img width="519" height="322" alt="image" src="https://github.com/user-attachments/assets/55de6026-89b4-4f78-9a6c-251e0f02b1c8" />
