### PR TITLE
(1 of 3) Fix bug collapsing scopes

### DIFF
--- a/pytest_spec/patch.py
+++ b/pytest_spec/patch.py
@@ -5,7 +5,7 @@
 
 import os
 import re
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, Generator, List, Optional, Tuple
 
 from _pytest.config import Config
 from _pytest.main import Session
@@ -21,6 +21,15 @@ BOUNDARIES_REGEXP = re.compile(
     """,
     re.VERBOSE,
 )
+
+
+def iterate_scope_hierarchy(previous: list[str], current: list[str]) -> Generator[tuple[int, str], None, None]:
+    yielding = False
+    for depth, scope in enumerate(current):
+        if depth >= len(previous) or scope != previous[depth]:
+            yielding = True
+        if yielding:
+            yield depth, scope
 
 
 def pytest_runtest_logstart(self, nodeid: str, location: Tuple[str, int, str]) -> None:
@@ -84,14 +93,10 @@ def pytest_runtest_logreport(self, report: TestReport) -> None:
         self.currentfspath = test_path
         _print_description(self)
 
-    scope_ind = 0
-    for msg in self.current_scopes:
-        if msg not in self.previous_scopes:
-            msg = [indent * scope_ind + prettify_description(msg)]
-            msg = "\n".join(msg)
-            if msg:
-                _print_description(self, msg)
-        scope_ind += 1
+    for scope_ind, scope in iterate_scope_hierarchy(self.previous_scopes, self.current_scopes):
+        msg = indent * scope_ind + prettify_description(scope)
+        if msg:
+            _print_description(self, msg)
     self.previous_scopes = self.current_scopes
 
     if not isinstance(word, tuple):

--- a/pytest_spec/patch.py
+++ b/pytest_spec/patch.py
@@ -24,6 +24,11 @@ BOUNDARIES_REGEXP = re.compile(
 
 
 def iterate_scope_hierarchy(previous: list[str], current: list[str]) -> Generator[tuple[int, str], None, None]:
+    """
+    Generates a (depth, scope) sequence for the current hierarchy starting from the first
+    level that differs from the previous hierarchy. This is used to process only the new
+    namespace depths when transitioning between two scope hirarchies.
+    """
     yielding = False
     for depth, scope in enumerate(current):
         if depth >= len(previous) or scope != previous[depth]:

--- a/test/test_patch.py
+++ b/test/test_patch.py
@@ -89,6 +89,35 @@ class TestPatch(unittest.TestCase):
         pytest_runtest_logreport(fake_self, FakeReport("Test::Second::Test_example_demo"))
         fake_self._tw.write.assert_has_calls([call("Second:")])
 
+    def test__pytest_runtest_logreport__does_not_collapse_different_containers_with_the_same_name(
+        self,
+    ):
+        nodeid1 = "Test::indent_one_level::describe_root1::describe_A::describe_B::describe_C::test_example_demo"
+        nodeid2 = "Test::indent_one_level::describe_root2::describe_A::describe_B::describe_C::test_example_demo"
+
+        fake_self = FakeSelf()
+        pytest_runtest_logreport(fake_self, FakeReport(nodeid1))
+        pytest_runtest_logreport(fake_self, FakeReport(nodeid2))
+
+        fake_self._tw.write.assert_has_calls(
+            [
+                call("Indent one level:"),
+                call("  Root 1:"),
+                call("    A:"),
+                call("      B:"),
+                call("        C:"),
+            ]
+        )
+
+        fake_self._tw.write.assert_has_calls(
+            [
+                call("  Root 2:"),
+                call("    A:"),
+                call("      B:"),
+                call("        C:"),
+            ]
+        )
+
     def test__pytest_runtest_logreport__prints_test_name_and_passed_status(self):
         fake_self = FakeSelf()
         pytest_runtest_logreport(fake_self, FakeReport("Test::Second::test_example_demo"))


### PR DESCRIPTION
## What's changing
This change fixes a bug that causes scopes to not be printed if they have the same name as a previous scope.

Example hierarchy:
```
Indent one level:
  Root 1:
    A:
      B:
        C:
          Demo test 1
  Root 2:
    A:
      B:
        C:
          Demo test 2
```

Output before this fix:
```
Indent one level:
  Root 1:
    A:
      B:
        C:
          Demo test 1
  Root 2:
          Demo test 2
```

Output after this fix:
```
Indent one level:
  Root 1:
    A:
      B:
        C:
          Demo test 1
  Root 2:
    A:
      B:
        C:
          Demo test 2
```
