### PR TITLE
(2 of 3) Add spec_container_format

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,12 +75,11 @@ In addition to the `{path}` and `{class_name}` replacement fields, there is also
 
 ### spec_container_format
 
-You can configure the format of the test containers by specifying a [format string](https://docs.python.org/2/library/string.html#format-string-syntax) in your [ini-file](https://docs.pytest.org/en/stable/customize.html#pytest-ini):
+You can configure the format of test container names (e.g., `describe_*` or `Test*` classes/methods) by specifying a [format string](https://docs.python.org/2/library/string.html#format-string-syntax) in your [ini-file](https://docs.pytest.org/en/stable/customize.html#pytest-ini):
 
-2 variables are available:
-
-- sentence - capitalize first letter and remove all underscores
-- unit_name - looks like the name of the unit under test
+**Available variables:**
+- `{sentence}` - Capitalize first letter, replace underscores with spaces, remove `describe_` prefix
+- `{unit_name}` - Raw name with `describe_` prefix removed, underscores preserved
 
 ```ini
     ; since pytest 4.6.x

--- a/README.md
+++ b/README.md
@@ -71,6 +71,46 @@ In addition to the `{path}` and `{class_name}` replacement fields, there is also
 
 <details>
 
+<summary>spec_container_format</summary>
+
+### spec_container_format
+
+You can configure the format of the test containers by specifying a [format string](https://docs.python.org/2/library/string.html#format-string-syntax) in your [ini-file](https://docs.pytest.org/en/stable/customize.html#pytest-ini):
+
+2 variables are available:
+
+- sentence - capitalize first letter and remove all underscores
+- unit_name - looks like the name of the unit under test
+
+```ini
+    ; since pytest 4.6.x
+    [pytest]
+    spec_container_format = {sentence}:
+
+    ; legacy pytest
+    [tool:pytest]
+    spec_container_format = {sentence}:
+```
+
+Similar configuration could be done in your [pyproject.toml](https://docs.pytest.org/en/stable/reference/customize.html#pyproject-toml) file:
+
+```toml
+    [tool.pytest.ini_options]
+    spec_container_format = "{sentence}:"
+```
+
+Here is an example of what the formatted output might look like:
+
+| Format    | Test Container                      | Formatted Output   |
+|-----------|-------------------------------------|--------------------|
+| sentence  | `class TestFibonacciSequence`       | Fibonacci Sequence |
+| sentence  | `def describe_fibonacci_sequence()` | Fibonacci sequence |
+| unit_name | `class TestFibonacciSequence`       | FibonacciSequence  |
+| unit_name | `def describe_fibonacci_sequence()` | fibonacci_sequence |
+</details>
+
+<details>
+
 <summary>spec_test_format</summary>
 
 ### spec_test_format

--- a/pytest_spec/patch.py
+++ b/pytest_spec/patch.py
@@ -99,9 +99,8 @@ def pytest_runtest_logreport(self, report: TestReport) -> None:
         _print_description(self)
 
     for scope_ind, scope in iterate_scope_hierarchy(self.previous_scopes, self.current_scopes):
-        msg = indent * scope_ind + prettify_description(scope)
-        if msg:
-            _print_description(self, msg)
+        container_name = _format_container_name(scope, self.config)
+        _print_description(self, indent * scope_ind + container_name)
     self.previous_scopes = self.current_scopes
 
     if not isinstance(word, tuple):
@@ -165,6 +164,16 @@ def _get_test_path(nodeid: str, header: str) -> str:
     )
 
 
+def _format_container_name(container: str, config) -> str:
+    unit_name = _remove_test_container_prefix(container)
+    sentence = prettify(unit_name)
+
+    return config.getini("spec_container_format").format(
+        sentence=sentence,
+        unit_name=unit_name,
+    )
+
+
 def _print_description(self, msg: Optional[str] = None) -> None:
     if msg is None:
         msg = self.currentfspath
@@ -176,7 +185,7 @@ def _print_description(self, msg: Optional[str] = None) -> None:
 
 
 def _remove_test_container_prefix(nodeid: str) -> str:
-    return re.sub("^(Test)|(describe)", "", nodeid)
+    return re.sub("^(Test)|(describe_?)", "", nodeid)
 
 
 def _remove_file_extension(nodeid: str) -> str:

--- a/pytest_spec/plugin.py
+++ b/pytest_spec/plugin.py
@@ -31,6 +31,11 @@ def pytest_addoption(parser: Parser) -> None:
         help="The format of the test headers when using the spec plugin",
     )
     parser.addini(
+        "spec_container_format",
+        default="{sentence}:",
+        help="The format of the test container when using the spec plugin",
+    )
+    parser.addini(
         "spec_test_format",
         default="{result} {name}",
         help="The format of the test results when using the spec plugin",

--- a/test/test_patch.py
+++ b/test/test_patch.py
@@ -24,6 +24,7 @@ class FakeConfig:
         self.hook = FakeHook(*args, **kwargs)
         self.mapping = {
             "spec_header_format": "{module_path}:",
+            "spec_container_format": "{sentence}:",
             "spec_test_format": "{result} {name}",
             "spec_success_indicator": "✓",
             "spec_failure_indicator": "✗",
@@ -82,12 +83,64 @@ class TestPatch(unittest.TestCase):
         result = pytest_runtest_logreport(FakeSelf(), FakeReport(""))
         self.assertIsNone(result)
 
-    def test__pytest_runtest_logreport__prints_class_name_before_first_test_result(
+    def test__pytest_runtest_logreport__prints_container_name_before_first_test_result(
         self,
     ):
         fake_self = FakeSelf()
         pytest_runtest_logreport(fake_self, FakeReport("Test::Second::Test_example_demo"))
-        fake_self._tw.write.assert_has_calls([call("Second:")])
+        fake_self._tw.write.assert_has_calls(
+            [
+                call("Second:"),
+                call("  ✓ Example demo", green=True),
+            ]
+        )
+
+    def test__pytest_runtest_logreport__uses_sentence_format_for_container_name(
+        self,
+    ):
+        fake_self = FakeSelf()
+        fake_self.config.mapping["spec_container_format"] = "{sentence}"
+        pytest_runtest_logreport(fake_self, FakeReport("Test::describe_first_container::Test_example_demo"))
+        fake_self._tw.write.assert_has_calls([call("First container")])
+
+    def test__pytest_runtest_logreport__uses_unit_name_format_for_container_name(
+        self,
+    ):
+        fake_self = FakeSelf()
+        fake_self.config.mapping["spec_container_format"] = "{unit_name}"
+        pytest_runtest_logreport(fake_self, FakeReport("Test::describe_first_container::Test_example_demo"))
+        fake_self._tw.write.assert_has_calls([call("first_container")])
+
+    def test__pytest_runtest_logreport__adds_indentation_for_each_nested_container(
+        self,
+    ):
+        fake_self = FakeSelf()
+        fake_self.config.mapping["spec_indent"] = "    "
+        pytest_runtest_logreport(fake_self, FakeReport("Test::describe_first_container::describe_second_container::Test_example_demo"))
+        fake_self._tw.write.assert_has_calls(
+            [
+                call("First container:"),
+                call("    Second container:"),
+            ]
+        )
+
+    def test__pytest_runtest_logreport__does_not_print_the_same_container_more_than_once(
+        self,
+    ):
+        fake_self = FakeSelf()
+        nodeid1 = "Test::describe_first_container::describe_second_container::Test_example_demo1"
+        nodeid2 = "Test::describe_first_container::describe_second_container::Test_example_demo2"
+        pytest_runtest_logreport(fake_self, FakeReport(nodeid1))
+        pytest_runtest_logreport(fake_self, FakeReport(nodeid2))
+
+        fake_self._tw.write.assert_has_calls(
+            [
+                call("First container:"),
+                call("  Second container:"),
+                call("    ✓ Example demo 1", green=True),
+                call("    ✓ Example demo 2", green=True),
+            ]
+        )
 
     def test__pytest_runtest_logreport__does_not_collapse_different_containers_with_the_same_name(
         self,


### PR DESCRIPTION
## What's changing
This change adds the `spec_container_format` to allow test container names to be formatted.

This PR introduces two formatting variables that can be used to format the test container names: `sentence` and `unit_name`.
### sentence
This is the way pytest-spec normally renders a container name. Capitalize first letter and replace all underscores with spaces.

### unit_name
This new format allows the text to look like the name of the function or the class that is under test.

For example, suppose you have a utility function named `def fibonacci_sequence(n)` that returns the first `n` values of the Fibonacci sequence. You might write a suite of tests like this:
```python
def describe_fibonacci_sequence():
  def it_returns_first_5_values():
    ...
```
If `spec_container_format = "{unit_name}:"`, then the output would be:
```
fibonacci_sequence:
  Returns first 5 values
```

This allows the test container to have the same name as the function that is being tested. Which helps provide context to the tests within container.