### PR TITLE
(3 of 3) Add container docstring override

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,46 @@ In addition to the `{path}` and `{class_name}` replacement fields, there is also
 
 <details>
 
+<summary>spec_container_format</summary>
+
+### spec_container_format
+
+You can configure the format of the test containers by specifying a [format string](https://docs.python.org/2/library/string.html#format-string-syntax) in your [ini-file](https://docs.pytest.org/en/stable/customize.html#pytest-ini):
+
+2 variables are available:
+
+- sentence - capitalize first letter and remove all underscores
+- unit_name - looks like the name of the unit under test
+
+```ini
+    ; since pytest 4.6.x
+    [pytest]
+    spec_container_format = {sentence}:
+
+    ; legacy pytest
+    [tool:pytest]
+    spec_container_format = {sentence}:
+```
+
+Similar configuration could be done in your [pyproject.toml](https://docs.pytest.org/en/stable/reference/customize.html#pyproject-toml) file:
+
+```toml
+    [tool.pytest.ini_options]
+    spec_container_format = "{sentence}:"
+```
+
+Here is an example of what the formatted output might look like:
+
+| Format    | Test Container                      | Formatted Output   |
+|-----------|-------------------------------------|--------------------|
+| sentence  | `class TestFibonacciSequence`       | Fibonacci Sequence |
+| sentence  | `def describe_fibonacci_sequence()` | Fibonacci sequence |
+| unit_name | `class TestFibonacciSequence`       | FibonacciSequence  |
+| unit_name | `def describe_fibonacci_sequence()` | fibonacci_sequence |
+</details>
+
+<details>
+
 <summary>spec_test_format</summary>
 
 ### spec_test_format

--- a/README.md
+++ b/README.md
@@ -165,6 +165,39 @@ or
 
 <details>
 
+<summary>spec_override_with_docstring</summary>
+
+### spec_override_with_docstring
+
+When `spec_override_with_docstring` is true then certian formatting variables will be overridden with the first line of the docstring.
+
+```ini
+    ; since pytest 4.6.x
+    [pytest]
+    spec_override_with_docstring = true
+
+    ; legacy pytest
+    [tool:pytest]
+    spec_override_with_docstring = true
+```
+
+Similar configuration could be done in your [pyproject.toml](https://docs.pytest.org/en/stable/reference/customize.html#pyproject-toml) file:
+
+```toml
+    [tool.pytest.ini_options]
+    spec_override_with_docstring = true
+```
+
+The format variables that will be overridden by the docstring are:
+| Format String         | Variables            |
+|-----------------------|----------------------|
+| spec_container_format | sentence, unit_name  |
+
+
+</details>
+
+<details>
+
 <summary>spec_success_indicator</summary>
 
 ### spec_success_indicator

--- a/pytest_spec/patch.py
+++ b/pytest_spec/patch.py
@@ -5,7 +5,7 @@
 
 import os
 import re
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, Generator, List, Optional, Tuple
 
 from _pytest.config import Config
 from _pytest.main import Session
@@ -21,6 +21,15 @@ BOUNDARIES_REGEXP = re.compile(
     """,
     re.VERBOSE,
 )
+
+
+def iterate_scope_hierarchy(previous: list[str], current: list[str]) -> Generator[tuple[int, str], None, None]:
+    yielding = False
+    for depth, scope in enumerate(current):
+        if depth >= len(previous) or scope != previous[depth]:
+            yielding = True
+        if yielding:
+            yield depth, scope
 
 
 def pytest_runtest_logstart(self, nodeid: str, location: Tuple[str, int, str]) -> None:
@@ -84,14 +93,10 @@ def pytest_runtest_logreport(self, report: TestReport) -> None:
         self.currentfspath = test_path
         _print_description(self)
 
-    scope_ind = 0
-    for msg in self.current_scopes:
-        if msg not in self.previous_scopes:
-            msg = [indent * scope_ind + prettify_description(msg)]
-            msg = "\n".join(msg)
-            if msg:
-                _print_description(self, msg)
-        scope_ind += 1
+    for scope_ind, scope in iterate_scope_hierarchy(self.previous_scopes, self.current_scopes):
+        msg = indent * scope_ind + prettify_description(scope)
+        if msg:
+            _print_description(self, msg)
     self.previous_scopes = self.current_scopes
 
     if not isinstance(word, tuple):

--- a/pytest_spec/patch.py
+++ b/pytest_spec/patch.py
@@ -94,9 +94,8 @@ def pytest_runtest_logreport(self, report: TestReport) -> None:
         _print_description(self)
 
     for scope_ind, scope in iterate_scope_hierarchy(self.previous_scopes, self.current_scopes):
-        msg = indent * scope_ind + prettify_description(scope)
-        if msg:
-            _print_description(self, msg)
+        container_name = _format_container_name(scope, self.config)
+        _print_description(self, indent * scope_ind + container_name)
     self.previous_scopes = self.current_scopes
 
     if not isinstance(word, tuple):
@@ -160,6 +159,16 @@ def _get_test_path(nodeid: str, header: str) -> str:
     )
 
 
+def _format_container_name(container: str, config) -> str:
+    unit_name = _remove_test_container_prefix(container)
+    sentence = prettify(unit_name)
+
+    return config.getini("spec_container_format").format(
+        sentence=sentence,
+        unit_name=unit_name,
+    )
+
+
 def _print_description(self, msg: Optional[str] = None) -> None:
     if msg is None:
         msg = self.currentfspath
@@ -171,7 +180,7 @@ def _print_description(self, msg: Optional[str] = None) -> None:
 
 
 def _remove_test_container_prefix(nodeid: str) -> str:
-    return re.sub("^(Test)|(describe)", "", nodeid)
+    return re.sub("^(Test)|(describe_?)", "", nodeid)
 
 
 def _remove_file_extension(nodeid: str) -> str:

--- a/pytest_spec/patch.py
+++ b/pytest_spec/patch.py
@@ -94,7 +94,12 @@ def pytest_runtest_logreport(self, report: TestReport) -> None:
         _print_description(self)
 
     for scope_ind, scope in iterate_scope_hierarchy(self.previous_scopes, self.current_scopes):
-        container_name = _format_container_name(scope, self.config)
+        describe = None
+        if getattr(report, "describe_hierarchy", None) and len(report.describe_hierarchy) == len(self.current_scopes):
+            describe = report.describe_hierarchy[-1 - scope_ind]
+
+        container = describe if describe and describe["name"] == scope and describe["doc"] else scope
+        container_name = _format_container_name(container, self.config)
         _print_description(self, indent * scope_ind + container_name)
     self.previous_scopes = self.current_scopes
 
@@ -159,9 +164,18 @@ def _get_test_path(nodeid: str, header: str) -> str:
     )
 
 
-def _format_container_name(container: str, config) -> str:
-    unit_name = _remove_test_container_prefix(container)
+def _format_container_name(container: str | dict[str, str], config) -> str:
+    if type(container) is dict:
+        unit_name = _remove_test_container_prefix(container["name"])
+        docstring = container["doc"]
+    elif type(container) is str:
+        unit_name = _remove_test_container_prefix(container)
+        docstring = ""
+
     sentence = prettify(unit_name)
+
+    if docstring and config.getini("spec_override_with_docstring"):
+        unit_name = sentence = docstring.splitlines()[0]
 
     return config.getini("spec_container_format").format(
         sentence=sentence,

--- a/pytest_spec/plugin.py
+++ b/pytest_spec/plugin.py
@@ -41,6 +41,11 @@ def pytest_addoption(parser: Parser) -> None:
         help="The format of the test results when using the spec plugin",
     )
     parser.addini(
+        "spec_override_with_docstring",
+        default=False,
+        help="Overrides variables in the container and test result formats with the first line of the docstring if it exists",
+    )
+    parser.addini(
         "spec_success_indicator",
         default="✓",
         help="The indicator displayed when a test passes",
@@ -89,3 +94,24 @@ def pytest_runtest_makereport(item: Item, call: CallInfo) -> Any:
         report.docstring_summary = str(item.obj.__doc__).lstrip().split("\n")  # type: ignore
     else:
         report.docstring_summary = []
+
+    # describe_hierarchy = item.get_describe_function_heirarchy() if hasattr(item, "get_describe_function_heirarchy") else None
+    # if describe_hierarchy is not None:
+    #     report.describe_hierarchy = [{"name": f.__name__, "doc": f.__doc__ or ""} for f in describe_hierarchy]
+    # else:
+    #     report.describe_hierarchy = _get_describe_hierarchy_by_duck_typing(item)
+    report.describe_hierarchy = _get_describe_hierarchy_by_duck_typing(item)
+
+
+def _get_describe_hierarchy_by_duck_typing(item: Item) -> list[dict[str, str]]:
+    hierarchy = []
+    parent = item.parent
+    while parent is not None:
+        class_name = parent.__class__.__name__
+        funcobj = getattr(parent, "funcobj", None)
+
+        if class_name == "DescribeBlock" and callable(funcobj):
+            hierarchy.append({"name": funcobj.__name__, "doc": funcobj.__doc__ or ""})
+
+        parent = parent.parent
+    return hierarchy

--- a/pytest_spec/plugin.py
+++ b/pytest_spec/plugin.py
@@ -31,6 +31,11 @@ def pytest_addoption(parser: Parser) -> None:
         help="The format of the test headers when using the spec plugin",
     )
     parser.addini(
+        "spec_container_format",
+        default="{sentence}:",
+        help="The format of the test container when using the spec plugin",
+    )
+    parser.addini(
         "spec_test_format",
         default="{result} {name}",
         help="The format of the test results when using the spec plugin",

--- a/test/test_patch.py
+++ b/test/test_patch.py
@@ -26,6 +26,7 @@ class FakeConfig:
             "spec_header_format": "{module_path}:",
             "spec_container_format": "{sentence}:",
             "spec_test_format": "{result} {name}",
+            "spec_override_with_docstring": False,
             "spec_success_indicator": "✓",
             "spec_failure_indicator": "✗",
             "spec_skipped_indicator": "?",
@@ -35,7 +36,7 @@ class FakeConfig:
 
     def getini(self, option):
         result = self.mapping.get(option, None)
-        if not result:
+        if option not in self.mapping:
             raise TypeError("Option {} is not supported in the test".format(option))
         return result
 
@@ -60,6 +61,10 @@ class FakeReport:
         self.failed = kwargs.get("failed", False)
         self.skipped = kwargs.get("skipped", False)
         self.docstring_summary = ["Test documentation"]
+
+
+def fake_describe_function_hierarchy(nodeid):
+    return [{"name": scope, "doc": ""} for scope in reversed(nodeid.split("::")[1:-1])]
 
 
 class TestPatch(unittest.TestCase):
@@ -170,6 +175,56 @@ class TestPatch(unittest.TestCase):
                 call("        C:"),
             ]
         )
+
+    def test__pytest_runtest_logreport__overrides_container_name_with_docstring(
+        self,
+    ):
+        formats = [
+            "{sentence}",
+            "{unit_name}",
+        ]
+
+        for f in formats:
+            fake_self = FakeSelf()
+            fake_self.config.mapping["spec_container_format"] = f
+            fake_self.config.mapping["spec_override_with_docstring"] = True
+            fake_report = FakeReport("Test::TestFibonacciSequence::describe_dijkstras_algorithm::test_example_docstring_override")
+            fake_report.describe_hierarchy = fake_describe_function_hierarchy(fake_report.nodeid)
+            fake_report.describe_hierarchy[0]["doc"] = "#dijkstras_algorithm()"
+            fake_report.describe_hierarchy[1]["doc"] = "#fibonacci_sequence()"
+
+            pytest_runtest_logreport(fake_self, fake_report)
+            fake_self._tw.write.assert_has_calls(
+                [
+                    call("#fibonacci_sequence()"),
+                    call("  #dijkstras_algorithm()"),
+                ]
+            )
+
+    def test__pytest_runtest_logreport__overrides_container_name_with_only_the_first_line_of_the_docstring(
+        self,
+    ):
+        fake_self = FakeSelf()
+        fake_self.config.mapping["spec_override_with_docstring"] = True
+        fake_report = FakeReport("Test::describe_dijkstras_algorithm::test_example_docstring_override")
+        fake_report.describe_hierarchy = fake_describe_function_hierarchy(fake_report.nodeid)
+        fake_report.describe_hierarchy[0]["doc"] = "line 1\nignored line 1\nignored line 2"
+        pytest_runtest_logreport(fake_self, fake_report)
+        for args, _ in fake_self._tw.write.call_args_list:
+            assert "ignored" not in args[0]
+
+    def test__pytest_runtest_logreport__does_not_override_container_name_with_docstring_if_docstring_is_not_available(
+        self,
+    ):
+        describe_hierarchies = [None, [], [{"name": "", "doc": "#dijkstras_algorithm()"}, {"name": "describe_dijkstras_algorithm", "doc": ""}]]
+
+        for describe_hierarchy in describe_hierarchies:
+            fake_self = FakeSelf()
+            fake_self.config.mapping["spec_override_with_docstring"] = True
+            fake_report = FakeReport("Test::describe_dijkstras_algorithm::test_example_docstring_override")
+            fake_report.describe_hierarchy = describe_hierarchy
+            pytest_runtest_logreport(fake_self, fake_report)
+            fake_self._tw.write.assert_has_calls([call("Dijkstras algorithm:")])
 
     def test__pytest_runtest_logreport__prints_test_name_and_passed_status(self):
         fake_self = FakeSelf()

--- a/test/test_patch.py
+++ b/test/test_patch.py
@@ -89,6 +89,35 @@ class TestPatch(unittest.TestCase):
         pytest_runtest_logreport(fake_self, FakeReport("Test::Second::Test_example_demo"))
         fake_self._tw.write.assert_has_calls([call("Second:")])
 
+    def test__pytest_runtest_logreport__does_not_collapse_different_containers_with_the_same_name(
+        self,
+    ):
+        nodeid1 = "Test::indent_one_level::describe_root1::describe_A::describe_B::describe_C::test_example_demo"
+        nodeid2 = "Test::indent_one_level::describe_root2::describe_A::describe_B::describe_C::test_example_demo"
+
+        fake_self = FakeSelf()
+        pytest_runtest_logreport(fake_self, FakeReport(nodeid1))
+        pytest_runtest_logreport(fake_self, FakeReport(nodeid2))
+
+        fake_self._tw.write.assert_has_calls(
+            [
+                call("Indent one level:"),
+                call("  Root 1:"),
+                call("    A:"),
+                call("      B:"),
+                call("        C:"),
+            ]
+        )
+
+        fake_self._tw.write.assert_has_calls(
+            [
+                call("  Root 2:"),
+                call("    A:"),
+                call("      B:"),
+                call("        C:"),
+            ]
+        )
+
     def test__pytest_runtest_logreport__prints_test_name_and_passed_status(self):
         fake_self = FakeSelf()
         pytest_runtest_logreport(fake_self, FakeReport("Test::Second::test_example_demo"))

--- a/test/test_patch.py
+++ b/test/test_patch.py
@@ -24,6 +24,7 @@ class FakeConfig:
         self.hook = FakeHook(*args, **kwargs)
         self.mapping = {
             "spec_header_format": "{module_path}:",
+            "spec_container_format": "{sentence}:",
             "spec_test_format": "{result} {name}",
             "spec_success_indicator": "✓",
             "spec_failure_indicator": "✗",
@@ -82,12 +83,64 @@ class TestPatch(unittest.TestCase):
         result = pytest_runtest_logreport(FakeSelf(), FakeReport(""))
         self.assertIsNone(result)
 
-    def test__pytest_runtest_logreport__prints_class_name_before_first_test_result(
+    def test__pytest_runtest_logreport__prints_container_name_before_first_test_result(
         self,
     ):
         fake_self = FakeSelf()
         pytest_runtest_logreport(fake_self, FakeReport("Test::Second::Test_example_demo"))
-        fake_self._tw.write.assert_has_calls([call("Second:")])
+        fake_self._tw.write.assert_has_calls(
+            [
+                call("Second:"),
+                call("  ✓ Example demo", green=True),
+            ]
+        )
+
+    def test__pytest_runtest_logreport__uses_sentence_format_for_container_name(
+        self,
+    ):
+        fake_self = FakeSelf()
+        fake_self.config.mapping["spec_container_format"] = "{sentence}"
+        pytest_runtest_logreport(fake_self, FakeReport("Test::describe_first_container::Test_example_demo"))
+        fake_self._tw.write.assert_has_calls([call("First container")])
+
+    def test__pytest_runtest_logreport__uses_unit_name_format_for_container_name(
+        self,
+    ):
+        fake_self = FakeSelf()
+        fake_self.config.mapping["spec_container_format"] = "{unit_name}"
+        pytest_runtest_logreport(fake_self, FakeReport("Test::describe_first_container::Test_example_demo"))
+        fake_self._tw.write.assert_has_calls([call("first_container")])
+
+    def test__pytest_runtest_logreport__adds_indentation_for_each_nested_container(
+        self,
+    ):
+        fake_self = FakeSelf()
+        fake_self.config.mapping["spec_indent"] = "    "
+        pytest_runtest_logreport(fake_self, FakeReport("Test::describe_first_container::describe_second_container::Test_example_demo"))
+        fake_self._tw.write.assert_has_calls(
+            [
+                call("First container:"),
+                call("    Second container:"),
+            ]
+        )
+
+    def test__pytest_runtest_logreport__does_not_print_the_same_container_more_than_once(
+        self,
+    ):
+        fake_self = FakeSelf()
+        nodeid1 = "Test::describe_first_container::describe_second_container::Test_example_demo1"
+        nodeid2 = "Test::describe_first_container::describe_second_container::Test_example_demo2"
+        pytest_runtest_logreport(fake_self, FakeReport(nodeid1))
+        pytest_runtest_logreport(fake_self, FakeReport(nodeid2))
+
+        fake_self._tw.write.assert_has_calls(
+            [
+                call("First container:"),
+                call("  Second container:"),
+                call("    ✓ Example demo 1", green=True),
+                call("    ✓ Example demo 2", green=True),
+            ]
+        )
 
     def test__pytest_runtest_logreport__does_not_collapse_different_containers_with_the_same_name(
         self,


### PR DESCRIPTION
## What's changing
This change allows the docstring on describe functions to override the formatting variables of the `spec_container_format` string.

Given:
```
def describe_fibonacci_sequence():
    """#fibonacci_sequence()""
    ...
```
Before this change:
```
Fibonacci sequence:
  ...
```

After this change:
```
#fibonacci_sequence()
  ...
```